### PR TITLE
16.0 attendance myarea

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,8 +45,17 @@ oca_run_tests
 
 To run tests for a specific module locally:
 
+```bash
+$ODOO_BIN -c odoo.conf -i module_name --test-enable
 ```
-python C:/Users/Piruin/Repository/odoo/odoo16/odoo-bin -c odoo.conf -i module_name --test-enable
+
+Set `ODOO_BIN` to the path of your local `odoo-bin` script, e.g.:
+
+```bash
+# .env or shell profile
+export ODOO_BIN=/path/to/odoo-bin          # macOS/Linux
+# or on Windows (PowerShell)
+$env:ODOO_BIN = "C:\path\to\odoo-bin"
 ```
 
 Use `-i` (install/update), not `--test-tags` alone — the latter skips the module update step that initialises ORM defaults and
@@ -61,7 +70,7 @@ Thai translations live in `<module>/i18n/th.po`. **Always regenerate the `.po` f
 strings are added to a module (new fields, view labels, filter strings, etc.). Use the export script in `.tools/`:
 
 ```bash
-ODOO_MODULE=<module_name> python <odoo-bin> shell -c odoo.conf -d <database> --no-http < .tools/export_po.py
+ODOO_MODULE=<module_name> $ODOO_BIN shell -c odoo.conf -d <database> --no-http < .tools/export_po.py
 ```
 
 - `ODOO_MODULE` defaults to `ni_patient`; `ODOO_LANG` defaults to `th_TH`

--- a/ni_community_care/models/__init__.py
+++ b/ni_community_care/models/__init__.py
@@ -1,6 +1,7 @@
 #  Copyright (c) 2023 NSTDA
-from . import hr_employee
+from . import ni_my_area_mixin
 from . import hr_employee_base
+from . import hr_employee
 from . import ir_rule
 from . import ni_careplan
 from . import ni_cc_report_monthly

--- a/ni_community_care/models/hr_employee.py
+++ b/ni_community_care/models/hr_employee.py
@@ -3,21 +3,8 @@ from odoo import api, fields, models
 
 
 class Employee(models.Model):
-    _inherit = "hr.employee"
-
-    my_area = fields.Boolean(compute="_compute_my_area", search="_search_my_area")
-
-    @api.depends("city_ids")
-    def _compute_my_area(self):
-        my_cities = self.env.user.city_ids.ids
-        for rec in self:
-            rec.my_area = bool(set(rec.city_ids.ids) & set(my_cities))
-
-    def _search_my_area(self, operator, value):
-        my_city_ids = self.env.user.city_ids.ids
-        if not my_city_ids:
-            return [("id", "=", 0)]
-        return [("city_ids", "in", my_city_ids)]
+    _inherit = ["hr.employee", "ni.my.area.mixin"]
+    _name = "hr.employee"
 
     def _sync_user(self, user, employee_has_image=False):
         vals = super()._sync_user(user, employee_has_image)

--- a/ni_community_care/models/ni_my_area_mixin.py
+++ b/ni_community_care/models/ni_my_area_mixin.py
@@ -1,0 +1,61 @@
+#  Copyright (c) 2025 NSTDA
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+def _my_area_depends(model):
+    deps = ["city_ids"] if "city_ids" in model._fields else ["city_id"]
+    deps += ["state_ids"] if "state_ids" in model._fields else ["state_id"]
+    return deps
+
+
+class MyAreaMixin(models.AbstractModel):
+    _name = "ni.my.area.mixin"
+    _description = "My Area Mixin"
+
+    my_area = fields.Boolean(
+        "พื้นที่ของฉัน", compute="_compute_my_area", search="_search_my_area"
+    )
+
+    @api.depends(_my_area_depends)
+    def _compute_my_area(self):
+        user = self.env.user
+        is_admin = self.user_has_groups("ni_patient.group_admin")
+        is_manager = self.user_has_groups("ni_patient.group_manager")
+        use_city_m2m = "city_ids" in self._fields
+        use_state_m2m = "state_ids" in self._fields
+        for rec in self:
+            if is_admin:
+                rec.my_area = True
+            elif is_manager:
+                if use_state_m2m:
+                    rec.my_area = bool(set(rec.state_ids.ids) & set(user.state_ids.ids))
+                else:
+                    rec.my_area = rec.state_id.id in user.state_ids.ids
+            elif use_city_m2m:
+                rec.my_area = bool(set(rec.city_ids.ids) & set(user.city_ids.ids))
+            else:
+                rec.my_area = rec.city_id.id in user.city_ids.ids
+
+    def _search_my_area(self, operator, operand):
+        if operator == "=":
+            if self.user_has_groups("ni_patient.group_admin"):
+                return [] if bool(operand) else [("id", "=", 0)]
+            if self.user_has_groups("ni_patient.group_manager"):
+                state_field = "state_ids" if "state_ids" in self._fields else "state_id"
+                return [
+                    (
+                        state_field,
+                        "in" if bool(operand) else "not in",
+                        self.env.user.state_ids.ids,
+                    )
+                ]
+            city_field = "city_ids" if "city_ids" in self._fields else "city_id"
+            return [
+                (
+                    city_field,
+                    "in" if bool(operand) else "not in",
+                    self.env.user.city_ids.ids,
+                )
+            ]
+        raise ValidationError(_("my_area support only '=', 'True' or 'False'"))

--- a/ni_community_care/models/ni_service_event_daily_report.py
+++ b/ni_community_care/models/ni_service_event_daily_report.py
@@ -7,6 +7,7 @@ from odoo.exceptions import ValidationError
 
 class ServiceEventDailyReport(models.Model):
     _name = "ni.service.event.daily.report"
+    _inherit = ["ni.my.area.mixin"]
     _description = "Service Event Daily Report"
     _order = "service_date desc"
     _auto = False
@@ -45,9 +46,6 @@ class ServiceEventDailyReport(models.Model):
     my_service = fields.Boolean(
         "รายการของฉัน", compute="_compute_my_service", search="_search_my_service"
     )
-    my_area = fields.Boolean(
-        "พื้นที่ของฉัน", compute="_compute_my_area", search="_search_my_area"
-    )
 
     @api.depends("employee_id")
     def _compute_my_service(self):
@@ -64,33 +62,6 @@ class ServiceEventDailyReport(models.Model):
                 )
             ]
         raise ValidationError(_("my_service support only '=', 'True' or 'False'"))
-
-    @api.depends("city_id", "state_id")
-    def _compute_my_area(self):
-        for rec in self:
-            if self.user_has_groups("ni_patient.group_manager"):
-                rec.my_area = rec.state_id.id in self.env.user.state_ids.ids
-            else:
-                rec.my_area = rec.city_id.id in self.env.user.city_ids.ids
-
-    def _search_my_area(self, operator, operand):
-        if operator == "=":
-            if self.user_has_groups("ni_patient.group_manager"):
-                return [
-                    (
-                        "state_id",
-                        "in" if bool(operand) else "not in",
-                        self.env.user.state_ids.ids,
-                    )
-                ]
-            return [
-                (
-                    "city_id",
-                    "in" if bool(operand) else "not in",
-                    self.env.user.city_ids.ids,
-                )
-            ]
-        raise ValidationError(_("my_area support only '=', 'True' or 'False'"))
 
     def init(self):
         tools.drop_view_if_exists(self.env.cr, self._table)

--- a/ni_community_care/models/ni_service_event_report.py
+++ b/ni_community_care/models/ni_service_event_report.py
@@ -8,6 +8,7 @@ from odoo.exceptions import ValidationError
 
 class ServiceEventReport(models.Model):
     _name = "ni.service.event.report"
+    _inherit = ["ni.my.area.mixin"]
     _description = "Service Event Report"
     _order = "start desc"
     _auto = False
@@ -54,7 +55,6 @@ class ServiceEventReport(models.Model):
     my_service = fields.Boolean(
         compute="_compute_my_service", search="_search_my_service"
     )
-    my_area = fields.Boolean(compute="_compute_my_area", search="_search_my_area")
 
     def action_service_event(self):
         self.ensure_one()
@@ -79,33 +79,6 @@ class ServiceEventReport(models.Model):
         if operator == "=":
             return [("user_id", "=" if bool(operand) else "!=", self.env.user.id)]
         raise ValidationError(_("my_service support only '=', 'True' or 'False'"))
-
-    @api.depends("city_id")
-    def _compute_my_area(self):
-        for rec in self:
-            if self.user_has_groups("ni_patient.group_manager"):
-                rec.my_area = rec.state_id.id in self.env.user.state_ids.ids
-            else:
-                rec.my_area = rec.city_id.id in self.env.user.city_ids.ids
-
-    def _search_my_area(self, operator, operand):
-        if operator == "=":
-            if self.user_has_groups("ni_patient.group_manager"):
-                return [
-                    (
-                        "state_id",
-                        "in" if bool(operand) else "not in",
-                        self.env.user.state_ids.ids,
-                    )
-                ]
-            return [
-                (
-                    "city_id",
-                    "in" if bool(operand) else "not in",
-                    self.env.user.city_ids.ids,
-                )
-            ]
-        raise ValidationError(_("my_area support only '=', 'True' or 'False'"))
 
     def init(self):
         tools.drop_view_if_exists(self.env.cr, self._table)

--- a/ni_community_care/models/res_users.py
+++ b/ni_community_care/models/res_users.py
@@ -1,10 +1,11 @@
 #  Copyright (c) 2025 NSTDA
 
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class Users(models.Model):
-    _inherit = "res.users"
+    _inherit = ["res.users", "ni.my.area.mixin"]
+    _name = "res.users"
 
     state_ids = fields.Many2many(
         "res.country.state",
@@ -22,20 +23,6 @@ class Users(models.Model):
         "พื้นที่รับผิดชอบ",
         domain="[('state_id', 'in', state_ids)]",
     )
-
-    my_area = fields.Boolean(compute="_compute_my_area", search="_search_my_area")
-
-    @api.depends("city_ids")
-    def _compute_my_area(self):
-        my_cities = self.env.user.city_ids.ids
-        for rec in self:
-            rec.my_area = bool(set(rec.city_ids.ids) & set(my_cities))
-
-    def _search_my_area(self, operator, value):
-        my_city_ids = self.env.user.city_ids.ids
-        if not my_city_ids:
-            return [("id", "=", 0)]
-        return [("city_ids", "in", my_city_ids)]
 
     def action_add_response_state_cities(self):
         city = self.env["res.city"].search([("state_id", "in", self.state_ids.ids)])

--- a/ni_community_care/tests/__init__.py
+++ b/ni_community_care/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import common
+from . import test_ni_my_area_mixin
 from . import test_ni_service_event

--- a/ni_community_care/tests/test_ni_my_area_mixin.py
+++ b/ni_community_care/tests/test_ni_my_area_mixin.py
@@ -1,0 +1,191 @@
+#  Copyright (c) 2025 NSTDA
+
+from odoo.exceptions import ValidationError
+from odoo.tests import TransactionCase
+
+
+class MyAreaMixinCommon(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        country = cls.env.ref("base.th")
+
+        cls.state = cls.env["res.country.state"].create(
+            {"name": "Test State A", "code": "TSA", "country_id": country.id}
+        )
+        cls.other_state = cls.env["res.country.state"].create(
+            {"name": "Test State B", "code": "TSB", "country_id": country.id}
+        )
+        cls.city = cls.env["res.city"].create(
+            {"name": "Test City A", "state_id": cls.state.id, "country_id": country.id}
+        )
+        cls.other_city = cls.env["res.city"].create(
+            {
+                "name": "Test City B",
+                "state_id": cls.other_state.id,
+                "country_id": country.id,
+            }
+        )
+
+        cls.admin_user = cls.env["res.users"].create(
+            {
+                "name": "Test Admin",
+                "login": "mixin_admin@test.com",
+                "groups_id": [(4, cls.env.ref("ni_patient.group_admin").id)],
+            }
+        )
+        cls.manager_user = cls.env["res.users"].create(
+            {
+                "name": "Test Manager",
+                "login": "mixin_manager@test.com",
+                "groups_id": [(4, cls.env.ref("ni_patient.group_manager").id)],
+                "state_ids": [(4, cls.state.id)],
+            }
+        )
+        cls.regular_user = cls.env["res.users"].create(
+            {
+                "name": "Test User",
+                "login": "mixin_user@test.com",
+                "groups_id": [(4, cls.env.ref("ni_patient.group_user").id)],
+                "city_ids": [(4, cls.city.id)],
+            }
+        )
+
+        cls.employee_in = cls.env["hr.employee"].create(
+            {
+                "name": "Employee In Area",
+                "state_ids": [(4, cls.state.id)],
+                "city_ids": [(4, cls.city.id)],
+            }
+        )
+        cls.employee_out = cls.env["hr.employee"].create(
+            {
+                "name": "Employee Out Of Area",
+                "state_ids": [(4, cls.other_state.id)],
+                "city_ids": [(4, cls.other_city.id)],
+            }
+        )
+
+
+class TestComputeMyAreaEmployee(MyAreaMixinCommon):
+    """_compute_my_area on hr.employee (city_ids / state_ids M2M path)."""
+
+    def test_admin_always_true_regardless_of_city(self):
+        self.assertTrue(self.employee_out.with_user(self.admin_user).my_area)
+
+    def test_admin_always_true_in_area(self):
+        self.assertTrue(self.employee_in.with_user(self.admin_user).my_area)
+
+    def test_manager_true_when_state_matches(self):
+        self.assertTrue(self.employee_in.with_user(self.manager_user).my_area)
+
+    def test_manager_false_when_state_no_match(self):
+        self.assertFalse(self.employee_out.with_user(self.manager_user).my_area)
+
+    def test_user_true_when_city_matches(self):
+        self.assertTrue(self.employee_in.with_user(self.regular_user).my_area)
+
+    def test_user_false_when_city_no_match(self):
+        self.assertFalse(self.employee_out.with_user(self.regular_user).my_area)
+
+
+class TestComputeMyAreaUser(MyAreaMixinCommon):
+    """_compute_my_area on res.users (city_ids / state_ids M2M path)."""
+
+    def test_admin_always_true(self):
+        self.assertTrue(self.regular_user.with_user(self.admin_user).my_area)
+
+    def test_manager_true_when_state_matches(self):
+        # manager_user's state_ids = [cls.state]; regular_user has no state → False
+        # Use manager_user itself as the record (it has state_ids = [cls.state])
+        self.assertTrue(self.manager_user.with_user(self.manager_user).my_area)
+
+    def test_user_true_when_city_matches(self):
+        self.assertTrue(self.regular_user.with_user(self.regular_user).my_area)
+
+    def test_user_false_when_city_no_match(self):
+        self.assertFalse(self.manager_user.with_user(self.regular_user).my_area)
+
+
+class TestSearchMyAreaEmployee(MyAreaMixinCommon):
+    """_search_my_area domain output on hr.employee (city_ids / state_ids path)."""
+
+    def _search(self, user, operand):
+        return self.env["hr.employee"].with_user(user)._search_my_area("=", operand)
+
+    def test_admin_true_returns_empty_domain(self):
+        self.assertEqual(self._search(self.admin_user, True), [])
+
+    def test_admin_false_returns_no_records_domain(self):
+        self.assertEqual(self._search(self.admin_user, False), [("id", "=", 0)])
+
+    def test_manager_true_filters_by_state_ids(self):
+        domain = self._search(self.manager_user, True)
+        self.assertEqual(domain, [("state_ids", "in", self.manager_user.state_ids.ids)])
+
+    def test_manager_false_excludes_state_ids(self):
+        domain = self._search(self.manager_user, False)
+        self.assertEqual(
+            domain, [("state_ids", "not in", self.manager_user.state_ids.ids)]
+        )
+
+    def test_user_true_filters_by_city_ids(self):
+        domain = self._search(self.regular_user, True)
+        self.assertEqual(domain, [("city_ids", "in", self.regular_user.city_ids.ids)])
+
+    def test_user_false_excludes_city_ids(self):
+        domain = self._search(self.regular_user, False)
+        self.assertEqual(
+            domain, [("city_ids", "not in", self.regular_user.city_ids.ids)]
+        )
+
+    def test_unsupported_operator_raises(self):
+        with self.assertRaises(ValidationError):
+            self._search(self.regular_user, True)
+            self.env["hr.employee"].with_user(self.regular_user)._search_my_area(
+                "!=", True
+            )
+
+
+class TestSearchMyAreaReport(MyAreaMixinCommon):
+    """_search_my_area domain output on ni.service.event.report (city_id / state_id path).
+
+    Report models are SQL views — no records are created; only the domain logic is
+    verified by calling the search method directly.
+    """
+
+    def _search(self, user, operand):
+        return (
+            self.env["ni.service.event.report"]
+            .with_user(user)
+            ._search_my_area("=", operand)
+        )
+
+    def test_admin_true_returns_empty_domain(self):
+        self.assertEqual(self._search(self.admin_user, True), [])
+
+    def test_manager_true_filters_by_state_id(self):
+        domain = self._search(self.manager_user, True)
+        self.assertEqual(domain, [("state_id", "in", self.manager_user.state_ids.ids)])
+
+    def test_manager_false_excludes_state_id(self):
+        domain = self._search(self.manager_user, False)
+        self.assertEqual(
+            domain, [("state_id", "not in", self.manager_user.state_ids.ids)]
+        )
+
+    def test_user_true_filters_by_city_id(self):
+        domain = self._search(self.regular_user, True)
+        self.assertEqual(domain, [("city_id", "in", self.regular_user.city_ids.ids)])
+
+    def test_user_false_excludes_city_id(self):
+        domain = self._search(self.regular_user, False)
+        self.assertEqual(
+            domain, [("city_id", "not in", self.regular_user.city_ids.ids)]
+        )
+
+    def test_unsupported_operator_raises(self):
+        with self.assertRaises(ValidationError):
+            self.env["ni.service.event.report"].with_user(
+                self.regular_user
+            )._search_my_area("!=", True)

--- a/ni_community_care/tests/test_ni_my_area_mixin.py
+++ b/ni_community_care/tests/test_ni_my_area_mixin.py
@@ -1,6 +1,10 @@
 #  Copyright (c) 2025 NSTDA
 
+from datetime import timedelta
+
+from odoo import fields
 from odoo.exceptions import ValidationError
+from odoo.fields import Command
 from odoo.tests import TransactionCase
 
 
@@ -189,3 +193,95 @@ class TestSearchMyAreaReport(MyAreaMixinCommon):
             self.env["ni.service.event.report"].with_user(
                 self.regular_user
             )._search_my_area("!=", True)
+
+
+class TestComputeMyAreaReport(MyAreaMixinCommon):
+    """_compute_my_area on ni.service.event.report / ni.service.event.daily.report
+    (city_id / state_id singular path).
+
+    Creates a complete service event stack so the SQL views have records.
+    Note: _compute_state_city on ni.service.event has a bugged @api.depends
+    (lists state_id/city_id instead of plan_patient_ids), so we call it manually
+    after event creation to populate the stored city/state from the patient.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.patient_type = cls.env["ni.patient.type"].create(
+            {"name": "Test Report Type"}
+        )
+        cls.category = cls.env["ni.service.category"].create(
+            {"name": "Test Report Category"}
+        )
+        cls.service = cls.env["ni.service"].create(
+            {
+                "name": "Test Report Service",
+                "category_id": cls.category.id,
+                "dayofweek": "0",
+            }
+        )
+
+        def make_patient(name, city, state):
+            patient = cls.env["ni.patient"].create({"name": name})
+            patient.partner_id.write({"city_id": city.id, "state_id": state.id})
+            return patient
+
+        cls.patient_in = make_patient("Patient In Area", cls.city, cls.state)
+        cls.patient_out = make_patient(
+            "Patient Out Area", cls.other_city, cls.other_state
+        )
+
+        def make_event(patient):
+            now = fields.Datetime.now()
+            event = cls.env["ni.service.event"].create(
+                {
+                    "name": "Test Report Event",
+                    "start": now,
+                    "stop": now + timedelta(hours=1),
+                    "service_id": cls.service.id,
+                    "service_ids": [Command.set([cls.service.id])],
+                    "patient_type_id": cls.patient_type.id,
+                    "service_category_id": cls.category.id,
+                    "plan_patient_ids": [Command.link(patient.id)],
+                }
+            )
+            event._compute_state_city()
+            return event
+
+        cls.event_in = make_event(cls.patient_in)
+        cls.event_out = make_event(cls.patient_out)
+
+        cls.report_in = cls.env["ni.service.event.report"].search(
+            [("event_id", "=", cls.event_in.id)], limit=1
+        )
+        cls.report_out = cls.env["ni.service.event.report"].search(
+            [("event_id", "=", cls.event_out.id)], limit=1
+        )
+        cls.daily_in = cls.env["ni.service.event.daily.report"].search(
+            [("employee_id", "=", cls.event_in.employee_id.id)], limit=1
+        )
+
+    def test_report_records_exist(self):
+        self.assertTrue(
+            self.report_in, "report_in record missing — check SQL view setup"
+        )
+        self.assertTrue(
+            self.report_out, "report_out record missing — check SQL view setup"
+        )
+
+    def test_admin_always_true(self):
+        self.assertTrue(self.report_in.with_user(self.admin_user).my_area)
+
+    def test_manager_true_when_state_matches(self):
+        self.assertTrue(self.report_in.with_user(self.manager_user).my_area)
+
+    def test_manager_false_when_state_no_match(self):
+        self.assertFalse(self.report_out.with_user(self.manager_user).my_area)
+
+    def test_user_true_when_city_matches(self):
+        self.assertTrue(self.report_in.with_user(self.regular_user).my_area)
+
+    def test_user_false_when_city_no_match(self):
+        self.assertFalse(self.report_out.with_user(self.regular_user).my_area)

--- a/ni_community_care_attendance/tests/__init__.py
+++ b/ni_community_care_attendance/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_hr_attendance_my_area

--- a/ni_community_care_attendance/tests/test_hr_attendance_my_area.py
+++ b/ni_community_care_attendance/tests/test_hr_attendance_my_area.py
@@ -1,0 +1,26 @@
+#  Copyright (c) 2025 NSTDA
+
+from odoo.tests import TransactionCase
+
+
+class TestHrAttendanceMyArea(TransactionCase):
+    def test_action_domain_scoped_to_my_area(self):
+        action = self.env.ref("hr_attendance.hr_attendance_action")
+        self.assertIn("employee_id.my_area", action.domain)
+
+    def test_action_overview_domain_scoped_to_my_area(self):
+        action = self.env.ref("hr_attendance.hr_attendance_action_overview")
+        self.assertIn("employee_id.my_area", action.domain)
+
+    def test_action_overview_view_mode_includes_kanban_and_form(self):
+        action = self.env.ref("hr_attendance.hr_attendance_action_overview")
+        view_modes = action.view_mode.split(",")
+        self.assertIn("kanban", view_modes)
+        self.assertIn("form", view_modes)
+
+    def test_my_area_filter_in_search_view(self):
+        view = self.env.ref(
+            "ni_community_care_attendance.hr_attendance_view_filter_inherit"
+        )
+        self.assertIn("my_area_employees", view.arch)
+        self.assertIn("employee_id.my_area", view.arch)

--- a/ni_community_care_attendance/views/hr_attendance_views.xml
+++ b/ni_community_care_attendance/views/hr_attendance_views.xml
@@ -73,4 +73,25 @@
             </kanban>
         </field>
     </record>
+    <record id="hr_attendance.hr_attendance_action" model="ir.actions.act_window">
+        <field name="domain">[('employee_id.my_area', '=', True)]</field>
+    </record>
+    <record id="hr_attendance.hr_attendance_action_overview" model="ir.actions.act_window">
+        <field name="domain">[('employee_id.my_area', '=', True)]</field>
+        <field name="view_mode">tree,kanban,form</field>
+    </record>
+    <record id="hr_attendance_view_filter_inherit" model="ir.ui.view">
+        <field name="name">hr.attendance.view.filter.my.area</field>
+        <field name="model">hr.attendance</field>
+        <field name="inherit_id" ref="hr_attendance.hr_attendance_view_filter" />
+        <field name="arch" type="xml">
+            <search>
+                <filter
+                    name="my_area_employees"
+                    string="ผู้บริบาลในพื้นที่รับผิดชอบ"
+                    domain="[('employee_id.my_area', '=', True)]"
+                />
+            </search>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
  ## [IMP] ni_community_care: extract my_area logic into MyAreaMixin
  - Extract duplicated `my_area` compute/search logic from `ni.service.event.report`,
    `ni.service.event.daily.report`, `hr.employee`, and `res.users` into a single
    `ni.my.area.mixin` abstract model
  - Mixin dynamically resolves field shape via `@api.depends` callable — uses
    `city_ids`/`state_ids` (M2M overlap) when available, falls back to `city_id`/`state_id`
  - Three-tier access: `group_admin` → always True, `group_manager` → state-level,
    user → city-level
  - Scope `hr.attendance` actions to `employee_id.my_area = True` and add search filter

  
  - [ ] my_area correct on report models (city_id/state_id path)
  - Mixin dynamically resolves field shape via `@api.depends` callable — uses
    `city_ids`/`state_ids` (M2M overlap) when available, falls back to `city_id`/`state_id`
  - Three-tier access: `group_admin` → always True, `group_manager` → state-level,
    user → city-level
  - Scope `hr.attendance` actions to `employee_id.my_area = True` and add search filter

  ## Test plan

  - [ ] my_area correct on report models (city_id/state_id path)
  - [ ] my_area correct on hr.employee and res.users (city_ids/state_ids M2M path)
  - [ ] admin always sees my_area = True
  - [ ] manager matches by state, user matches by city
  - [ ] attendance actions scoped to current user's area
  - [ ] "พื้นที่ของฉัน" filter appears in attendance search view
