### PR TITLE
[IMP] .claude: screenshot-odoo skill

### DIFF
--- a/.claude/skills/screenshot-odoo/SKILL.md
+++ b/.claude/skills/screenshot-odoo/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: screenshot-odoo
+description: >-
+  Take screenshots of the running Nirun/Odoo app at http://localhost:16669. Use when asked to show the UI, verify a feature
+  visually, take screenshots for a PR, or confirm a change works in the browser. Invoke as /screenshot-odoo [optional:
+  comma-separated list of views to capture].
+---
+
+# Odoo Screenshot Skill
+
+Takes screenshots of the Nirun Odoo app using Node Playwright (headless Chromium).
+
+## Prerequisites
+
+Requirements:
+
+- Node.js 20 or newer
+- A resolvable Node `playwright` package
+- Chromium browser binaries installed for that Playwright version
+
+Standard setup:
+
+```bash
+npm install --save-dev playwright
+npx playwright install chromium
+```
+
+If your environment already bundles Playwright in a nonstandard location, set `PLAYWRIGHT_MODULE` to a path that Node can
+`require(...)`.
+
+Optional agent-centric setup:
+
+```bash
+npx playwright-cli --help
+```
+
+`playwright-cli` can help with browser tooling for some agents, but this helper script still runs against the Node `playwright`
+library.
+
+## Configuration
+
+Environment variables:
+
+- `ODOO_BASE_URL`: defaults to `http://localhost:16669`
+- `ODOO_DB`: optional database name; recommended for multi-database Odoo instances
+- `ODOO_LOGIN`: defaults to `admin`
+- `ODOO_ADMIN_PWD`: required
+- `ODOO_SHOTS_DIR`: optional output directory; defaults to an OS temp folder
+- `PLAYWRIGHT_MODULE`: optional override when `playwright` is not on the normal Node resolution path
+
+## Workflow
+
+1. Read `.claude/skills/screenshot-odoo/odoo_screenshot.mjs`
+2. Copy it to a temp file, filling in the `# ------- VIEWS -------` section
+3. Export `ODOO_ADMIN_PWD` and any optional overrides such as `ODOO_DB`
+4. Run the temp copy from a shell
+5. Return the captured screenshots to the user using your runtime's normal file or inline-image mechanism
+6. Ask user if there want to save into module's `/static/screenshot/`
+
+## Script
+
+Base script: `.claude/skills/screenshot-odoo/odoo_screenshot.mjs`
+
+Helpers already defined there: `resolveConfig()`, `login()`, `dismiss()`, `screenshot()`, `actionId()`.
+
+Add views inside `run()` after `await login(page)`:
+
+```js
+// Resolve action to numeric ID (required - hash URLs reject xml IDs)
+const aid = await actionId(page, "ni_flag.ni_flag_action");
+
+// Navigate and shoot
+await page.goto(`${config.baseUrl}/web#action=${aid}`);
+await page.waitForLoadState("domcontentloaded");
+shots.push(await screenshot(page, config.outDir, "flag_list"));
+
+// Form record
+await page.goto(`${config.baseUrl}/web#action=${aid}&id=1&view_type=form`);
+await page.waitForLoadState("domcontentloaded");
+shots.push(await screenshot(page, config.outDir, "flag_form"));
+
+// Pivot
+await page.goto(`${config.baseUrl}/web#action=${aid}&view_type=pivot`);
+await page.waitForLoadState("domcontentloaded");
+shots.push(await screenshot(page, config.outDir, "flag_pivot"));
+
+// Patient kanban
+const patientActionId = await actionId(page, "ni_patient.patient_action");
+await page.goto(`${config.baseUrl}/web#action=${patientActionId}&view_type=kanban`);
+await page.waitForLoadState("domcontentloaded");
+shots.push(await screenshot(page, config.outDir, "patient_kanban", 2500));
+```
+
+## Running
+
+```bash
+node /path/to/temp/odoo_ss.mjs
+```
+
+Output lines after `---` are absolute paths to saved PNGs.
+
+Runtime notes:
+
+- In Codex, prefer returning screenshots inline in the response or as local file links.
+- In Claude, return screenshots using Claude's normal file-sharing path.
+
+## Odoo Server
+
+If the Odoo server is not already running, start it using the repo's normal Odoo command for your platform. In this repo, the
+portable pattern is:
+
+```bash
+$ODOO_BIN -c odoo.conf --http-port=16669
+```
+
+Wait ~5 s before navigating.
+
+## Known Issues
+
+- `waitForLoadState("networkidle")` hangs because of Odoo long-polling. Use `"domcontentloaded"` plus an explicit wait.
+- `#action=xml.id` does not work. Resolve the XML ID to a numeric action first with `actionId()`.
+- Multi-database Odoo setups may reject valid credentials unless `ODOO_DB` is set.
+- A custom action XML ID can still fail if the local Odoo registry is missing the target model. Try a core action first to
+  separate environment issues from helper issues.
+- `searchpanel` only accepts `many2one` or `selection`, never `many2many` or `one2many`.
+- Dismiss startup dialogs before shooting. `dismiss()` is best-effort, not a guarantee.
+- If Playwright cannot be imported, install the Node package or set `PLAYWRIGHT_MODULE`.
+
+## Action XML IDs (project reference)
+
+| View                | XML ID                                       |
+| ------------------- | -------------------------------------------- |
+| Patient list/kanban | `ni_patient.patient_action`                  |
+| Encounter list      | `ni_patient.ni_encounter_action`             |
+| Flags               | `ni_flag.ni_flag_action`                     |
+| Flag Codes          | `ni_flag.ni_flag_code_action`                |
+| Observations        | `ni_observation.ni_observation_sheet_action` |
+| Conditions          | `ni_condition.ni_condition_action`           |

--- a/.claude/skills/screenshot-odoo/odoo_screenshot.mjs
+++ b/.claude/skills/screenshot-odoo/odoo_screenshot.mjs
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 NSTDA
+import fs from "node:fs/promises";
+import {existsSync} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import {createRequire} from "node:module";
+import {pathToFileURL} from "node:url";
+
+const require = createRequire(import.meta.url);
+
+export function resolveConfig(env = process.env, tempDir = os.tmpdir()) {
+  const password = env.ODOO_ADMIN_PWD?.trim();
+  if (!password) {
+    throw new Error("Missing ODOO_ADMIN_PWD. Set the admin web password before running the screenshot helper.");
+  }
+
+  const baseUrl = (env.ODOO_BASE_URL || "http://localhost:16669").replace(/\/+$/, "");
+  const database = env.ODOO_DB?.trim() || null;
+  const login = env.ODOO_LOGIN || "admin";
+  const outDir = path.resolve(env.ODOO_SHOTS_DIR || path.join(tempDir, "odoo_shots"));
+
+  return {
+    baseUrl,
+    database,
+    login,
+    outDir,
+    password,
+    playwrightModule: env.PLAYWRIGHT_MODULE || "playwright",
+  };
+}
+
+export function buildLoginUrl(config) {
+  if (!config.database) {
+    return `${config.baseUrl}/web/login`;
+  }
+
+  return `${config.baseUrl}/web/login?db=${encodeURIComponent(config.database)}`;
+}
+
+export function extractActionId(payload, xmlid) {
+  if (payload?.error) {
+    const rpcMessage = payload.error.message || "RPC error";
+    const serverName = payload.error.data?.name;
+    const serverMessage = payload.error.data?.message;
+    const details = [rpcMessage];
+    if (serverName) {
+      details.push(`(${serverName})`);
+    }
+    if (serverMessage) {
+      details.push(`: ${serverMessage}`);
+    }
+    throw new Error(`Failed to resolve action ${xmlid}. ${details.join("")}`);
+  }
+
+  const actionId = payload?.result?.id;
+  if (!Number.isInteger(actionId)) {
+    throw new Error(`Action XML ID did not resolve to a numeric action: ${xmlid}`);
+  }
+
+  return actionId;
+}
+
+export function loadPlaywright(playwrightModule = "playwright") {
+  try {
+    if (existsSync(playwrightModule)) {
+      const resolutionRoot =
+        path.basename(playwrightModule) === "playwright" ? path.dirname(playwrightModule) : playwrightModule;
+      const resolvedModule = require.resolve("playwright", {
+        paths: [resolutionRoot],
+      });
+      return require(resolvedModule);
+    }
+
+    return require(playwrightModule);
+  } catch (error) {
+    throw new Error(
+      `Unable to load Playwright from "${playwrightModule}". Install the Node Playwright package or set PLAYWRIGHT_MODULE to a resolvable package path.\n` +
+        `Original error: ${error.message}`
+    );
+  }
+}
+
+async function dismiss(page) {
+  for (const selector of [".o_dialog .btn-primary", ".o_dialog button.btn"]) {
+    try {
+      const button = page.locator(selector).first();
+      await button.waitFor({state: "visible", timeout: 400});
+      await button.click();
+      await page.waitForTimeout(200);
+    } catch (error) {
+      console.warn(`WARN dismiss failed for selector ${selector}: ${error.message}`);
+    }
+  }
+}
+
+async function screenshot(page, outDir, name, wait = 2000) {
+  await page.waitForTimeout(wait);
+  await dismiss(page);
+  await page.waitForTimeout(300);
+
+  const shotPath = path.resolve(outDir, `${name}.png`);
+  await page.screenshot({path: shotPath, fullPage: false});
+  console.log(`OK ${name}`);
+  return shotPath;
+}
+
+async function login(page, config) {
+  await page.goto(buildLoginUrl(config));
+  await page.waitForLoadState("domcontentloaded");
+  if (config.database) {
+    const databaseField = page.locator("input[name=db]");
+    if ((await databaseField.count()) > 0) {
+      await databaseField.fill(config.database);
+    }
+  }
+  await page.fill("input[name=login]", config.login);
+  await page.fill("input[name=password]", config.password);
+  await page.locator("button[type=submit]").click();
+  await page.waitForTimeout(4000);
+
+  if (page.url().includes("/web/login")) {
+    throw new Error("Login failed. Check ODOO_LOGIN, ODOO_ADMIN_PWD, and ODOO_DB.");
+  }
+}
+
+async function actionId(page, xmlid) {
+  const payload = await page.evaluate(async (currentXmlId) => {
+    const response = await fetch("/web/action/load", {
+      method: "POST",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "call",
+        id: 1,
+        params: {
+          action_id: currentXmlId,
+        },
+      }),
+    });
+    return response.json();
+  }, xmlid);
+
+  return extractActionId(payload, xmlid);
+}
+
+export async function run(customEnv = process.env) {
+  const config = resolveConfig(customEnv);
+  const {chromium} = loadPlaywright(config.playwrightModule);
+
+  await fs.mkdir(config.outDir, {recursive: true});
+
+  const shots = [];
+  const browser = await chromium.launch({headless: true});
+  try {
+    const page = await browser.newPage({viewport: {width: 1440, height: 900}});
+    await login(page, config);
+
+    // ------- VIEWS -------
+    // Replace or extend this section per task.
+    // Pattern:
+    //   const aid = await actionId(page, "module.action_xmlid");
+    //   await page.goto(`${config.baseUrl}/web#action=${aid}`);
+    //   await page.waitForLoadState("domcontentloaded");
+    //   shots.push(await screenshot(page, config.outDir, "descriptive_name"));
+
+    console.log("WARN no views configured in the helper copy");
+  } finally {
+    await browser.close();
+  }
+
+  console.log("---");
+  for (const shotPath of shots) {
+    console.log(shotPath);
+  }
+}
+
+export {actionId, dismiss, login, screenshot};
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  run().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/.claude/skills/screenshot-odoo/odoo_screenshot.test.mjs
+++ b/.claude/skills/screenshot-odoo/odoo_screenshot.test.mjs
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 NSTDA
+import path from "node:path";
+import {test} from "node:test";
+import assert from "node:assert/strict";
+
+import {buildLoginUrl, extractActionId, resolveConfig} from "./odoo_screenshot.mjs";
+
+test("resolveConfig uses portable defaults and normalizes the base URL", () => {
+  const config = resolveConfig(
+    {
+      ODOO_ADMIN_PWD: "x",
+    },
+    "C:\\Temp"
+  );
+
+  assert.equal(config.baseUrl, "http://localhost:16669");
+  assert.equal(config.login, "admin");
+  assert.equal(config.password, "x");
+  assert.equal(config.outDir, path.resolve("C:\\Temp", "odoo_shots"));
+});
+
+test("resolveConfig keeps an optional database name and builds a db-aware login URL", () => {
+  const config = resolveConfig(
+    {
+      ODOO_ADMIN_PWD: "x",
+      ODOO_DB: "nirun-dc-master",
+    },
+    "/tmp"
+  );
+
+  assert.equal(config.database, "nirun-dc-master");
+  assert.equal(buildLoginUrl(config), "http://localhost:16669/web/login?db=nirun-dc-master");
+});
+
+test("resolveConfig throws when the admin password is missing", () => {
+  assert.throws(() => resolveConfig({}, "/tmp"), /ODOO_ADMIN_PWD/);
+});
+
+test("extractActionId returns the numeric id from a successful payload", () => {
+  assert.equal(extractActionId({result: {id: 42}}, "ni_flag.ni_flag_action"), 42);
+});
+
+test("extractActionId throws when the RPC payload reports an error", () => {
+  assert.throws(
+    () =>
+      extractActionId(
+        {
+          error: {
+            message: "Odoo Server Error",
+            data: {
+              name: "builtins.KeyError",
+              message: "Missing action",
+            },
+          },
+        },
+        "x_demo.missing_action"
+      ),
+    /Failed to resolve action x_demo\.missing_action\. Odoo Server Error\(builtins.KeyError\): Missing action/
+  );
+});
+
+test("extractActionId throws when the XML action does not resolve", () => {
+  assert.throws(() => extractActionId({result: null}, "ni_flag.missing_action"), /ni_flag\.missing_action/);
+});

--- a/docs/superpowers/plans/2026-06-08-screenshot-odoo-portability.md
+++ b/docs/superpowers/plans/2026-06-08-screenshot-odoo-portability.md
@@ -1,0 +1,108 @@
+<!-- Copyright (c) 2026 NSTDA -->
+
+# Screenshot Odoo Portability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the `screenshot-odoo` skill portable across Codex and Claude by replacing the Python-only helper with a
+cross-platform Node/Playwright helper and shared runtime-agnostic instructions.
+
+**Architecture:** Keep a single skill entrypoint in `.claude/skills/screenshot-odoo/`. Replace `odoo_screenshot.py` with a Node
+ESM helper that reads configuration from environment variables, uses OS temp paths, and fails loudly on configuration or action
+lookup errors. Update `SKILL.md` to describe generic shell-based execution plus an optional `playwright-cli` path.
+
+**Tech Stack:** Markdown skill docs, Node.js ESM, Playwright for Node
+
+---
+
+### Task 1: Plan And Branch Context
+
+**Files:**
+
+- Modify: `.claude/skills/screenshot-odoo/SKILL.md`
+- Modify: `.claude/skills/screenshot-odoo/odoo_screenshot.py`
+- Create: `docs/superpowers/plans/2026-06-08-screenshot-odoo-portability.md`
+
+- [ ] **Step 1: Confirm the current branch and existing skill files**
+
+Run: `git status --short --branch` Expected: branch is `16.0-imp-screenshot-skill` with no tracked changes to the skill files
+yet.
+
+- [ ] **Step 2: Record the implementation scope in this plan file**
+
+Write this file so the shared-entrypoint design and validation steps are captured before code changes begin.
+
+### Task 2: Replace The Helper Script
+
+**Files:**
+
+- Delete: `.claude/skills/screenshot-odoo/odoo_screenshot.py`
+- Create: `.claude/skills/screenshot-odoo/odoo_screenshot.mjs`
+
+- [ ] **Step 1: Write the helper with portable configuration**
+
+Create a Node ESM helper that:
+
+- reads `ODOO_BASE_URL`, `ODOO_LOGIN`, `ODOO_ADMIN_PWD`, and `ODOO_SHOTS_DIR`
+- uses `os.tmpdir()` when `ODOO_SHOTS_DIR` is unset
+- resolves file paths with `path`
+- prints absolute screenshot paths after a `---` separator
+
+- [ ] **Step 2: Make failure modes explicit**
+
+Implement checks that:
+
+- throw if `ODOO_ADMIN_PWD` is missing
+- throw if the login request returns to `/web/login`
+- throw if action lookup returns no numeric id
+- surface RPC errors from `/web/action/load`
+
+- [ ] **Step 3: Preserve the view-injection workflow**
+
+Keep a `# ------- VIEWS -------` block so the skill can still copy the helper to a temp file and append task-specific captures.
+
+### Task 3: Rewrite The Shared Skill Instructions
+
+**Files:**
+
+- Modify: `.claude/skills/screenshot-odoo/SKILL.md`
+
+- [ ] **Step 1: Replace runtime-specific assumptions**
+
+Remove Claude-only wording such as `Bash tool`, `SendUserFile`, and `desktop-commander`, and replace it with generic shell-based
+instructions that work in Codex and Claude.
+
+- [ ] **Step 2: Document portable setup**
+
+Add:
+
+- Node.js and Playwright prerequisites
+- the standard Playwright browser install command
+- environment variables for base URL, login, password, and output directory
+- Codex and Claude output guidance as plain runtime notes
+
+- [ ] **Step 3: Add an optional Playwright CLI note**
+
+Document `playwright-cli` as an optional execution path for agents that already use it, without making it the primary
+implementation path.
+
+### Task 4: Validate The Skill
+
+**Files:**
+
+- Test: `.claude/skills/screenshot-odoo/odoo_screenshot.mjs`
+- Test: `.claude/skills/screenshot-odoo/SKILL.md`
+
+- [ ] **Step 1: Run a syntax-level validation**
+
+Run: `node --check .claude/skills/screenshot-odoo/odoo_screenshot.mjs` Expected: exit code `0`
+
+- [ ] **Step 2: Run a live capture against local Odoo**
+
+Use a temp copy of the helper with a known XML action such as `ni_flag.ni_flag_action`, set `ODOO_ADMIN_PWD`, and run the script
+with Playwright available. Expected: one or more `OK <name>` lines and absolute PNG paths after `---`
+
+- [ ] **Step 3: Confirm the doc matches reality**
+
+Re-read `SKILL.md` and ensure the documented commands and environment variables match the helper that was validated.


### PR DESCRIPTION
## What changed

Add `.claude/skills/screenshot-odoo/` project skill for headless Odoo UI screenshots via Playwright.

- `SKILL.md` — workflow docs, known gotchas, action XML ID reference table

## Why

Headless Odoo screenshotting has several non-obvious pitfalls that kept causing failures during ni_flag development. Captures them once so future sessions don't rediscover them.

Closes #

## Scope

`.claude/skills/` only — no production code touched.

## Risk / Impact

None. Dev tooling only.

## How tested

- [ ] Unit/integration tests
- [ ] Manual check
- [x] Not tested / explain why: skill invoked and verified during ni_flag PR #95 development — screenshots produced correctly

## Documentation

- [ ] `docs/worklog.md` updated
- [ ] `docs/decisions.md` updated if decision changed
- [x] Not needed

## Notes for reviewer

- Known gotchas documented in `SKILL.md`: `networkidle` ban, numeric action ID requirement, searchpanel field-type restriction
- Script lives in skill dir so Claude reads it directly instead of re-deriving it each session