### PR TITLE
[FIX] ni_patient: use company timezone for encounter auto-close midnight cutoff

### DIFF
--- a/ni_patient/models/ni_encounter_class.py
+++ b/ni_patient/models/ni_encounter_class.py
@@ -1,7 +1,9 @@
 #  Copyright (c) 2021-2023 NSTDA
 
 import logging
+from datetime import datetime, time
 
+import pytz
 from dateutil.relativedelta import relativedelta
 
 from odoo import _, api, fields, models
@@ -39,7 +41,11 @@ class EncounterClassification(models.Model):
     report_title = fields.Char(default="Summary Report")
 
     auto_close = fields.Boolean(default=False)
-    auto_close_midnight = fields.Boolean(default=True)
+    auto_close_midnight = fields.Boolean(
+        default=True,
+        help="Use local midnight (encounter company's timezone, falling back to "
+        "UTC) as the day boundary, instead of a fixed elapsed duration",
+    )
     auto_close_offset_number = fields.Integer(default=1, readonly=False)
     auto_close_offset_type = fields.Selection(
         [
@@ -89,32 +95,49 @@ class EncounterClassification(models.Model):
         if not self._check_recursion():
             raise models.ValidationError(_("Error! You cannot create recursive data."))
 
+    def _get_auto_close_reference_time(self, now, company):
+        """Reference instant (UTC-naive, comparable to create_date) before
+        which an in-progress encounter of this class is eligible to close.
+
+        For the midnight-offset mode, the day boundary is computed in the
+        encounter company's timezone (falling back to UTC), not in raw
+        UTC - otherwise the cutoff drifts by the company's UTC offset,
+        closing encounters early or late around local midnight.
+        """
+        self.ensure_one()
+        if self.auto_close_midnight:
+            tz_name = company.resource_calendar_id.tz or "UTC"
+            tz = pytz.timezone(tz_name)
+            today_local = pytz.utc.localize(now).astimezone(tz).date()
+            rev_date = today_local - relativedelta(days=self.auto_close_offset_number)
+            rev_local_eod = tz.localize(datetime.combine(rev_date, time.max))
+            return rev_local_eod.astimezone(pytz.utc).replace(tzinfo=None)
+        offset = {self.auto_close_offset_type: self.auto_close_offset_number}
+        return now - relativedelta(**offset)
+
     @api.model
     def cron_auto_close(self):
         now = fields.Datetime.now()
         classes = self.search([("auto_close", "=", True)])
         enc_model = self.env["ni.encounter"]
         for cls in classes:
-            if cls.auto_close_midnight:
-                offset = {"days": cls.auto_close_offset_number}
-                rev = now.date() - relativedelta(**offset)
-            else:
-                offset = {cls.auto_close_offset_type: cls.auto_close_offset_number}
-                rev = now - relativedelta(**offset)
-            logging.debug(
-                "%s encounter: auto-close reference time = %s" % (cls.name, rev)
-            )
-            enc = enc_model.search(
-                [
-                    ("class_id", "=", cls.id),
-                    ("state", "=", "in-progress"),
-                    ("create_date", "<=", rev),
-                ],
+            candidates = enc_model.search(
+                [("class_id", "=", cls.id), ("state", "=", "in-progress")],
                 order="id",
             )
-            if enc:
-                enc.action_close()
-                _logger.info("%s encounter: Closed  ids=%s" % (cls.name, enc.ids))
+            to_close = enc_model
+            for company in candidates.mapped("company_id"):
+                rev = cls._get_auto_close_reference_time(now, company)
+                logging.debug(
+                    "%s encounter: auto-close reference time (company=%s) = %s"
+                    % (cls.name, company.name, rev)
+                )
+                to_close |= candidates.filtered(
+                    lambda e, rev=rev: e.company_id == company and e.create_date <= rev
+                )
+            if to_close:
+                to_close.action_close()
+                _logger.info("%s encounter: Closed  ids=%s" % (cls.name, to_close.ids))
             else:
                 _logger.info(
                     "%s encounter: Not found any encounter to close" % cls.name

--- a/ni_patient/tests/__init__.py
+++ b/ni_patient/tests/__init__.py
@@ -1,3 +1,8 @@
 #  Copyright (c) 2023 NSTDA
 
-from . import test_ni_patient, test_ni_workflow
+from . import (
+    test_ni_encounter_class_auto_close,
+    test_ni_encounter_class_auto_close_edge_cases,
+    test_ni_patient,
+    test_ni_workflow,
+)

--- a/ni_patient/tests/common.py
+++ b/ni_patient/tests/common.py
@@ -1,5 +1,7 @@
 #  Copyright (c) 2021-2023 NSTDA
 
+from unittest.mock import patch
+
 from odoo.tests import common
 
 
@@ -20,3 +22,52 @@ class TestPatientCommon(common.TransactionCase):
             }
         )
         self.patient_admin = self.env["ni.patient"].with_user(patient_admin)
+
+
+class TestEncounterAutoCloseCommon(common.TransactionCase):
+    """Shared fixtures/helpers for `ni.encounter.class.cron_auto_close()`
+    tests, split across baseline behaviour and timezone edge cases."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env["res.partner"].create({"name": "Auto Close Test Patient"})
+        cls.patient = cls.env["ni.patient"].create({"partner_id": cls.partner.id})
+
+        cls.class_midnight = cls.env["ni.encounter.class"].create(
+            {
+                "name": "Auto Close Midnight Test",
+                "auto_close": True,
+                "auto_close_midnight": True,
+                "auto_close_offset_number": 1,
+            }
+        )
+        cls.class_offset = cls.env["ni.encounter.class"].create(
+            {
+                "name": "Auto Close Hours Test",
+                "auto_close": True,
+                "auto_close_midnight": False,
+                "auto_close_offset_type": "hours",
+                "auto_close_offset_number": 6,
+            }
+        )
+        cls.class_disabled = cls.env["ni.encounter.class"].create(
+            {"name": "Auto Close Disabled Test", "auto_close": False}
+        )
+
+    def _make_encounter(self, enc_class, state="in-progress", create_date=None):
+        encounter = self.env["ni.encounter"].create(
+            {"patient_id": self.patient.id, "class_id": enc_class.id}
+        )
+        encounter.write({"state": state})
+        if create_date is not None:
+            self.env.cr.execute(
+                "UPDATE ni_encounter SET create_date = %s WHERE id = %s",
+                (create_date, encounter.id),
+            )
+            encounter.invalidate_recordset(["create_date"])
+        return encounter
+
+    def _run_cron(self, now):
+        with patch("odoo.fields.Datetime.now", return_value=now):
+            self.env["ni.encounter.class"].cron_auto_close()

--- a/ni_patient/tests/common.py
+++ b/ni_patient/tests/common.py
@@ -71,3 +71,6 @@ class TestEncounterAutoCloseCommon(common.TransactionCase):
     def _run_cron(self, now):
         with patch("odoo.fields.Datetime.now", return_value=now):
             self.env["ni.encounter.class"].cron_auto_close()
+
+    def _set_company_tz(self, tz_name):
+        self.patient.company_id.resource_calendar_id.tz = tz_name

--- a/ni_patient/tests/test_ni_encounter_class_auto_close.py
+++ b/ni_patient/tests/test_ni_encounter_class_auto_close.py
@@ -6,8 +6,14 @@ from .common import TestEncounterAutoCloseCommon
 
 
 class TestEncounterClassAutoClose(TestEncounterAutoCloseCommon):
-    """Baseline behaviour of cron_auto_close(). Timezone-sensitive edge
-    cases live in test_ni_encounter_class_auto_close_edge_cases.py."""
+    """Baseline behaviour of cron_auto_close(), with the company timezone
+    pinned to UTC so results don't depend on local-midnight logic.
+    Timezone-sensitive edge cases live in
+    test_ni_encounter_class_auto_close_edge_cases.py."""
+
+    def setUp(self):
+        super().setUp()
+        self._set_company_tz("UTC")
 
     def test_closes_encounter_past_offset(self):
         now = datetime(2026, 1, 10, 6, 0, 0)
@@ -18,8 +24,8 @@ class TestEncounterClassAutoClose(TestEncounterAutoCloseCommon):
         self.assertEqual(encounter.state, "finished")
 
     def test_keeps_encounter_within_offset(self):
-        # A bare `date` value compared with "<=" is end-of-day inclusive in
-        # Odoo (see osv/expression.py), so the whole UTC calendar day the
+        # The offset day boundary is end-of-day inclusive (see
+        # _get_auto_close_reference_time), so the whole calendar day the
         # encounter was created on is protected - only strictly earlier
         # days are eligible to close.
         now = datetime(2026, 1, 10, 6, 0, 0)

--- a/ni_patient/tests/test_ni_encounter_class_auto_close.py
+++ b/ni_patient/tests/test_ni_encounter_class_auto_close.py
@@ -1,0 +1,63 @@
+#  Copyright (c) 2026 NSTDA
+
+from datetime import datetime, timedelta
+
+from .common import TestEncounterAutoCloseCommon
+
+
+class TestEncounterClassAutoClose(TestEncounterAutoCloseCommon):
+    """Baseline behaviour of cron_auto_close(). Timezone-sensitive edge
+    cases live in test_ni_encounter_class_auto_close_edge_cases.py."""
+
+    def test_closes_encounter_past_offset(self):
+        now = datetime(2026, 1, 10, 6, 0, 0)
+        encounter = self._make_encounter(
+            self.class_midnight, create_date=datetime(2026, 1, 8, 10, 0, 0)
+        )
+        self._run_cron(now)
+        self.assertEqual(encounter.state, "finished")
+
+    def test_keeps_encounter_within_offset(self):
+        # A bare `date` value compared with "<=" is end-of-day inclusive in
+        # Odoo (see osv/expression.py), so the whole UTC calendar day the
+        # encounter was created on is protected - only strictly earlier
+        # days are eligible to close.
+        now = datetime(2026, 1, 10, 6, 0, 0)
+        encounter = self._make_encounter(
+            self.class_midnight, create_date=datetime(2026, 1, 10, 1, 0, 0)
+        )
+        self._run_cron(now)
+        self.assertEqual(encounter.state, "in-progress")
+
+    def test_ignores_disabled_class(self):
+        now = datetime(2026, 1, 10, 6, 0, 0)
+        encounter = self._make_encounter(
+            self.class_disabled, create_date=datetime(2026, 1, 1, 0, 0, 0)
+        )
+        self._run_cron(now)
+        self.assertEqual(encounter.state, "in-progress")
+
+    def test_ignores_non_in_progress_state(self):
+        now = datetime(2026, 1, 10, 6, 0, 0)
+        encounter = self._make_encounter(
+            self.class_midnight,
+            state="draft",
+            create_date=datetime(2026, 1, 1, 0, 0, 0),
+        )
+        self._run_cron(now)
+        self.assertEqual(encounter.state, "draft")
+
+    def test_hours_offset_uses_full_datetime_not_date(self):
+        # Non-midnight branch compares full datetimes (now - offset), so it
+        # is not affected by the UTC/date-only bug covered in the edge
+        # case test file.
+        now = datetime(2026, 1, 10, 12, 0, 0)
+        kept = self._make_encounter(
+            self.class_offset, create_date=now - timedelta(hours=5)
+        )
+        closed = self._make_encounter(
+            self.class_offset, create_date=now - timedelta(hours=7)
+        )
+        self._run_cron(now)
+        self.assertEqual(kept.state, "in-progress")
+        self.assertEqual(closed.state, "finished")

--- a/ni_patient/tests/test_ni_encounter_class_auto_close_edge_cases.py
+++ b/ni_patient/tests/test_ni_encounter_class_auto_close_edge_cases.py
@@ -6,15 +6,18 @@ from .common import TestEncounterAutoCloseCommon
 
 
 class TestEncounterClassAutoCloseCutoffBoundary(TestEncounterAutoCloseCommon):
-    """Minute-precision checks of the "<=" cutoff comparison itself,
-    independent of the timezone bug covered below."""
+    """Minute-precision checks of the "<=" cutoff comparison itself, with
+    the company timezone pinned to UTC so results don't depend on the
+    local-midnight logic covered below."""
+
+    def setUp(self):
+        super().setUp()
+        self._set_company_tz("UTC")
 
     def test_midnight_offset_cutoff_boundary_minute_precision(self):
-        # rev = now.date() - 1 day = 2026-01-09, but a bare `date` compared
-        # with "<=" is end-of-day inclusive in Odoo (osv/expression.py
-        # turns it into `datetime.combine(rev, time.max)`), so the real
-        # boundary is the rollover from 2026-01-09 23:59 to 2026-01-10
-        # 00:00 - not "midnight" of 2026-01-09 itself.
+        # rev is now built from an explicit end-of-day instant in the
+        # company timezone (here UTC), so the boundary is the rollover
+        # from 2026-01-09 23:59:59.999999 to 2026-01-10 00:00:00.
         now = datetime(2026, 1, 10, 6, 0, 0)
 
         one_minute_before_rollover = self._make_encounter(
@@ -58,55 +61,49 @@ class TestEncounterClassAutoCloseCutoffBoundary(TestEncounterAutoCloseCommon):
         )
 
 
-class TestEncounterClassAutoCloseTimezoneBug(TestEncounterAutoCloseCommon):
+class TestEncounterClassAutoCloseLocalMidnight(TestEncounterAutoCloseCommon):
     """
-    cron_auto_close() reasons entirely in UTC: fields.Datetime.now() is
-    UTC-naive, and the midnight branch keys off now.date(). No company or
-    user timezone is applied anywhere, so the code's day boundary is always
-    UTC midnight - never local midnight. For UTC+7 (Thailand), local
-    midnight happens 7 hours before UTC midnight, so an encounter that has
-    genuinely been open for a full local day can still be treated as
-    "today" by the code for up to 7 more hours, then close abruptly the
-    moment the UTC date rolls over - a boundary with no local meaning.
+    Regression coverage for nirun-life/nirun#102: cron_auto_close()'s
+    midnight-offset mode used to key off UTC midnight unconditionally
+    (via now.date()), so a company running ahead of UTC (e.g. Thailand,
+    UTC+7) could keep an encounter open for up to 7 extra hours past its
+    real local due time, then close it abruptly whenever the UTC date
+    happened to roll over - a boundary with no local meaning.
 
-    These tests pin the exact instants where that shows up, down to the
-    minute, since the cron's flakiness is a pure wall-clock artifact of
-    when it happens to fire - not something tied to any particular
-    encounter. See nirun-life/nirun#102.
+    _get_auto_close_reference_time() now derives the day boundary from
+    the encounter company's timezone (res.company.resource_calendar_id.tz,
+    falling back to UTC). These tests pin a company on Asia/Bangkok and
+    check the cutoff to the minute.
     """
 
-    def test_encounter_still_open_one_minute_after_it_should_have_closed_locally(self):
+    def setUp(self):
+        super().setUp()
+        self._set_company_tz("Asia/Bangkok")
+
+    def test_flips_at_local_midnight_not_utc_midnight(self):
         # Encounter created 2026-01-01 12:00 Bangkok (UTC+7) = 05:00 UTC.
-        # Local business rule (1 day offset): eligible to close starting
-        # local midnight of 2026-01-02, i.e. 2026-01-01 17:00 UTC.
+        # 1-day offset: eligible to close starting local midnight of
+        # 2026-01-02, i.e. 2026-01-01 17:00 UTC.
         create_date = datetime(2026, 1, 1, 5, 0, 0)
         encounter = self._make_encounter(self.class_midnight, create_date=create_date)
 
-        # One minute before the local boundary: correctly still open.
+        # One minute before local midnight: still open.
         self._run_cron(datetime(2026, 1, 1, 16, 59, 0))
         self.assertEqual(encounter.state, "in-progress")
 
-        # One minute after the local boundary - a full local day has now
-        # elapsed since creation, so this should close. But the UTC
-        # calendar date is still "2026-01-01" (UTC midnight is still 7
-        # hours away), so the code's cutoff hasn't moved and it stays
-        # open. This documents the bug; flip to "finished" once a
-        # timezone-aware cutoff is implemented.
+        # One minute after local midnight: closes immediately - unlike
+        # the pre-fix behaviour, which ignored the company timezone and
+        # would only close 7 hours later, at UTC midnight.
         self._run_cron(datetime(2026, 1, 1, 17, 1, 0))
-        self.assertEqual(encounter.state, "in-progress")
+        self.assertEqual(encounter.state, "finished")
 
-    def test_close_decision_flips_on_a_utc_rollover_one_minute_apart(self):
-        # Same encounter as above, followed forward: nothing about it, or
-        # about elapsed local time, changes meaningfully between these two
-        # cron runs - only the UTC calendar date ticks over, 1 minute
-        # apart. That alone flips the outcome, a full 7 hours after the
-        # true local boundary (2026-01-01 17:00 UTC, see test above) had
-        # already passed.
+    def test_no_longer_waits_for_the_old_utc_rollover(self):
+        # Same scenario: before the fix, this encounter only closed once
+        # the UTC calendar date rolled over at 2026-01-02 00:00 UTC. It
+        # now closes hours earlier, right after local midnight
+        # (2026-01-01 17:00 UTC) - well before that old instant.
         create_date = datetime(2026, 1, 1, 5, 0, 0)
         encounter = self._make_encounter(self.class_midnight, create_date=create_date)
 
-        self._run_cron(datetime(2026, 1, 1, 23, 59, 0))
-        self.assertEqual(encounter.state, "in-progress")
-
-        self._run_cron(datetime(2026, 1, 2, 0, 0, 0))
+        self._run_cron(datetime(2026, 1, 1, 20, 0, 0))
         self.assertEqual(encounter.state, "finished")

--- a/ni_patient/tests/test_ni_encounter_class_auto_close_edge_cases.py
+++ b/ni_patient/tests/test_ni_encounter_class_auto_close_edge_cases.py
@@ -1,0 +1,112 @@
+#  Copyright (c) 2026 NSTDA
+
+from datetime import datetime, timedelta
+
+from .common import TestEncounterAutoCloseCommon
+
+
+class TestEncounterClassAutoCloseCutoffBoundary(TestEncounterAutoCloseCommon):
+    """Minute-precision checks of the "<=" cutoff comparison itself,
+    independent of the timezone bug covered below."""
+
+    def test_midnight_offset_cutoff_boundary_minute_precision(self):
+        # rev = now.date() - 1 day = 2026-01-09, but a bare `date` compared
+        # with "<=" is end-of-day inclusive in Odoo (osv/expression.py
+        # turns it into `datetime.combine(rev, time.max)`), so the real
+        # boundary is the rollover from 2026-01-09 23:59 to 2026-01-10
+        # 00:00 - not "midnight" of 2026-01-09 itself.
+        now = datetime(2026, 1, 10, 6, 0, 0)
+
+        one_minute_before_rollover = self._make_encounter(
+            self.class_midnight, create_date=datetime(2026, 1, 9, 23, 59, 0)
+        )
+        one_minute_after_rollover = self._make_encounter(
+            self.class_midnight, create_date=datetime(2026, 1, 10, 0, 1, 0)
+        )
+
+        self._run_cron(now)
+
+        self.assertEqual(
+            one_minute_before_rollover.state,
+            "finished",
+            "still within the offset day, 1 minute before the day rolls over",
+        )
+        self.assertEqual(
+            one_minute_after_rollover.state,
+            "in-progress",
+            "already the next day, 1 minute after the rollover, must stay open",
+        )
+
+    def test_hours_offset_cutoff_boundary_minute_precision(self):
+        now = datetime(2026, 1, 10, 12, 0, 0)
+        cutoff = now - timedelta(hours=6)  # class_offset: 6 hours
+
+        before = self._make_encounter(
+            self.class_offset, create_date=cutoff - timedelta(minutes=1)
+        )
+        at_cutoff = self._make_encounter(self.class_offset, create_date=cutoff)
+        after = self._make_encounter(
+            self.class_offset, create_date=cutoff + timedelta(minutes=1)
+        )
+
+        self._run_cron(now)
+
+        self.assertEqual(before.state, "finished", "1 minute before cutoff must close")
+        self.assertEqual(at_cutoff.state, "finished", "exact cutoff is inclusive (<=)")
+        self.assertEqual(
+            after.state, "in-progress", "1 minute after cutoff must stay open"
+        )
+
+
+class TestEncounterClassAutoCloseTimezoneBug(TestEncounterAutoCloseCommon):
+    """
+    cron_auto_close() reasons entirely in UTC: fields.Datetime.now() is
+    UTC-naive, and the midnight branch keys off now.date(). No company or
+    user timezone is applied anywhere, so the code's day boundary is always
+    UTC midnight - never local midnight. For UTC+7 (Thailand), local
+    midnight happens 7 hours before UTC midnight, so an encounter that has
+    genuinely been open for a full local day can still be treated as
+    "today" by the code for up to 7 more hours, then close abruptly the
+    moment the UTC date rolls over - a boundary with no local meaning.
+
+    These tests pin the exact instants where that shows up, down to the
+    minute, since the cron's flakiness is a pure wall-clock artifact of
+    when it happens to fire - not something tied to any particular
+    encounter. See nirun-life/nirun#102.
+    """
+
+    def test_encounter_still_open_one_minute_after_it_should_have_closed_locally(self):
+        # Encounter created 2026-01-01 12:00 Bangkok (UTC+7) = 05:00 UTC.
+        # Local business rule (1 day offset): eligible to close starting
+        # local midnight of 2026-01-02, i.e. 2026-01-01 17:00 UTC.
+        create_date = datetime(2026, 1, 1, 5, 0, 0)
+        encounter = self._make_encounter(self.class_midnight, create_date=create_date)
+
+        # One minute before the local boundary: correctly still open.
+        self._run_cron(datetime(2026, 1, 1, 16, 59, 0))
+        self.assertEqual(encounter.state, "in-progress")
+
+        # One minute after the local boundary - a full local day has now
+        # elapsed since creation, so this should close. But the UTC
+        # calendar date is still "2026-01-01" (UTC midnight is still 7
+        # hours away), so the code's cutoff hasn't moved and it stays
+        # open. This documents the bug; flip to "finished" once a
+        # timezone-aware cutoff is implemented.
+        self._run_cron(datetime(2026, 1, 1, 17, 1, 0))
+        self.assertEqual(encounter.state, "in-progress")
+
+    def test_close_decision_flips_on_a_utc_rollover_one_minute_apart(self):
+        # Same encounter as above, followed forward: nothing about it, or
+        # about elapsed local time, changes meaningfully between these two
+        # cron runs - only the UTC calendar date ticks over, 1 minute
+        # apart. That alone flips the outcome, a full 7 hours after the
+        # true local boundary (2026-01-01 17:00 UTC, see test above) had
+        # already passed.
+        create_date = datetime(2026, 1, 1, 5, 0, 0)
+        encounter = self._make_encounter(self.class_midnight, create_date=create_date)
+
+        self._run_cron(datetime(2026, 1, 1, 23, 59, 0))
+        self.assertEqual(encounter.state, "in-progress")
+
+        self._run_cron(datetime(2026, 1, 2, 0, 0, 0))
+        self.assertEqual(encounter.state, "finished")


### PR DESCRIPTION
## Summary
- `cron_auto_close()` computed the day boundary from `fields.Datetime.now()` (UTC-naive), so companies ahead of UTC (e.g. Thailand, UTC+7) had the local-midnight cutoff drift up to 7 hours, causing the "Encounter class: Auto-close" cron to appear flaky.
- Derives the day boundary from each encounter's company timezone (`res.company.resource_calendar_id.tz`, falling back to UTC), grouping candidates per company.
- Adds unit tests covering baseline `cron_auto_close()` behavior plus minute-precision edge cases pinning the timezone bug.

Fixes #102.

## Test plan
- [x] `test_ni_encounter_class_auto_close.py` and `test_ni_encounter_class_auto_close_edge_cases.py` added/updated
- [ ] Run `oca_install_addons && oca_init_test_database && oca_run_tests` (or `$ODOO_BIN -c odoo.conf -i ni_patient --test-enable`) in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)