### PR TITLE
[IMP] ni_goal, ni_observation: goal target-match status and coded hierarchy

### DIFF
--- a/ni_goal/README.md
+++ b/ni_goal/README.md
@@ -31,8 +31,34 @@ observation measures, and provides a guided state-change workflow that can recor
   condition-to-goal coding relationship.
 - A goal's measure is an `ni.observation.type` (`observation_type_id`), restricted to `int`/`float`/`code_id`/`code_ids` value
   types. Numeric measures use `target_min`/`target_max`; Single Choice (`code_id`) and Multi Choice (`code_ids`) measures use
-  `target_code_ids` (a set of acceptable `ni.observation.value.code` values) with `target_code_operator` describing how they
-  should be matched. `ni.goal.code` carries the same target shape as a reusable template, copied onto `ni.goal` on selection.
+  `target_code_ids` (a set of acceptable `ni.observation.value.code` values) with `target_code_operator` deciding how the
+  observed value(s) on the latest matching observation must relate to that set (implemented in `ni.goal._match_target_code`):
+
+  - `=` (Match) — the observed values are exactly the same set as the target set (order doesn't matter).
+  - `!=` (Not Match) — the observed values are not exactly the same set as the target set.
+  - `in` (Contain) — every observed value is a member of the target set (the observed set may be a subset).
+  - `not in` (Not Contain) — no observed value is a member of the target set (fully disjoint).
+  - `child_of` (Child of) — every observed value is a descendant of, or equal to, some target value, walking
+    `ni.observation.value.code`'s `parent_id` hierarchy.
+  - `parent_of` (Parent of) — every observed value is an ancestor of, or equal to, some target value, walking the same
+    hierarchy.
+
+  `ni.goal.code` carries the same target shape (including `target_code_operator`) as a reusable template, copied onto `ni.goal`
+  on selection.
+
+- For numeric measures, `ni.goal.code.target_type` decides how the template's `target_min`/`target_max` are derived when applied
+  to a goal (in `ni.goal._onchange_code_id`):
+
+  - `fix` (Fix Value) — `target_fix_min`/`target_fix_max` are copied onto the goal's `target_min`/`target_max` as-is, a fixed
+    absolute range.
+  - `ratio` (Ratio) — the goal's `target_min`/`target_max` are computed as the patient's current observation value multiplied by
+    `target_ratio_min`/`target_ratio_max` (e.g. a ratio of `0.9`-`1.1` targets within 90%-110% of the patient's value at the
+    time the goal is created), so the range is relative to that patient rather than a fixed number.
+
+- `target_status` (computed, not stored) compares the latest observation (`observation_id`) against the target and renders as an
+  "In Target"/"Out of Target" badge on the goal form and the state wizard. `target_alert_message` (computed) warns on the state
+  wizard when there isn't enough evidence to judge progress: no baseline (`address_observation_id`) has been recorded yet, or a
+  baseline exists but the latest observation is still that same baseline record (nothing measured since).
 
 ## Security and Dependencies
 

--- a/ni_goal/i18n/th.po
+++ b/ni_goal/i18n/th.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-02 10:05+0000\n"
-"PO-Revision-Date: 2026-07-02 10:05+0000\n"
+"POT-Creation-Date: 2026-07-03 05:58+0000\n"
+"PO-Revision-Date: 2026-07-03 05:58+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -421,6 +421,16 @@ msgid "Fix Value"
 msgstr "ค่าคงที่"
 
 #. module: ni_goal
+#: model:ir.model.fields,help:ni_goal.field_ni_goal_code__target_fix_min
+msgid "Fixed lower bound applied when Target Type is 'Fix Value'."
+msgstr "ขอบเขตล่างคงที่ที่ใช้เมื่อประเภทเป้าหมายเป็น 'ค่าคงที่'"
+
+#. module: ni_goal
+#: model:ir.model.fields,help:ni_goal.field_ni_goal_code__target_fix_max
+msgid "Fixed upper bound applied when Target Type is 'Fix Value'."
+msgstr "ขอบเขตบนคงที่ที่ใช้เมื่อประเภทเป้าหมายเป็น 'ค่าคงที่'"
+
+#. module: ni_goal
 #: model:ir.model.fields,field_description:ni_goal.field_ni_goal_state__fold
 msgid "Fold"
 msgstr ""
@@ -536,6 +546,40 @@ msgid "History"
 msgstr "ประวัติ"
 
 #. module: ni_goal
+#: model:ir.model.fields,help:ni_goal.field_ni_goal_code__target_type
+msgid ""
+"How the numeric target range (target_min/target_max) is derived when this "
+"template is applied to a goal: 'Fix Value' copies "
+"target_fix_min/target_fix_max as-is; 'Ratio' multiplies the patient's "
+"current observation value by target_ratio_min/target_ratio_max (e.g. a ratio"
+" of 0.9-1.1 targets within 90%-110% of the patient's value at the time the "
+"goal is created)."
+msgstr ""
+"ช่วงเป้าหมายตัวเลข (target_min/target_max) ถูกคำนวณอย่างไรเมื่อแม่แบบนี้ถูกนำไปใช้กับเป้าหมาย: "
+"'ค่าคงที่' คัดลอก target_fix_min/target_fix_max มาใช้ตรงๆ; "
+"'อัตราส่วน' คูณค่าที่วัดได้ล่าสุดของผู้รับบริการด้วย target_ratio_min/target_ratio_max "
+"(เช่น อัตราส่วน 0.9-1.1 กำหนดเป้าหมายในช่วง 90%-110% ของค่าผู้รับบริการ ณ เวลาที่สร้างเป้าหมาย)"
+
+#. module: ni_goal
+#: model:ir.model.fields,help:ni_goal.field_ni_goal__target_code_operator
+#: model:ir.model.fields,help:ni_goal.field_ni_goal_code__target_code_operator
+#: model:ir.model.fields,help:ni_goal.field_ni_goal_state_wizard__target_code_operator
+msgid ""
+"How the observed value(s) must relate to the target codes: 'Match'/'Not "
+"Match' compare the observed values against the target set exactly (order "
+"doesn't matter); 'Contain'/'Not Contain' require every observed value to be "
+"(not be) a member of the target set; 'Child of'/'Parent of' require every "
+"observed value to be a descendant/ancestor (or itself) of some target value,"
+" walking the target codes' parent hierarchy."
+msgstr ""
+"ค่าที่วัดได้ต้องสัมพันธ์กับรหัสเป้าหมายอย่างไร: 'ตรงกัน'/'ไม่ตรงกัน' "
+"เปรียบเทียบค่าที่วัดได้กับชุดเป้าหมายแบบทั้งหมด (ไม่สนลำดับ); 'มี'/'ไม่มี' "
+"กำหนดให้ค่าที่วัดได้ทุกค่าต้องเป็น (หรือไม่เป็น) สมาชิกของชุดเป้าหมาย; "
+"'เป็นรายการย่อยของ'/'เป็นรายการหลักของ' "
+"กำหนดให้ค่าที่วัดได้ทุกค่าต้องเป็นรายการย่อย/รายการหลัก (หรือค่าเดียวกัน) "
+"ของรหัสเป้าหมายรายการใดรายการหนึ่ง โดยไล่ตามลำดับชั้นของรหัสเป้าหมาย"
+
+#. module: ni_goal
 #: model:ir.model.fields,field_description:ni_goal.field_ni_goal__id
 #: model:ir.model.fields,field_description:ni_goal.field_ni_goal_achievement__id
 #: model:ir.model.fields,field_description:ni_goal.field_ni_goal_category__id
@@ -579,6 +623,11 @@ msgstr "ดีขึ้น"
 #: model:ni.goal.achievement,name:ni_goal.goal_in_progress
 msgid "In Progress"
 msgstr "ระหว่างดำเนินการ"
+
+#. module: ni_goal
+#: model:ir.model.fields.selection,name:ni_goal.selection__ni_goal__target_status__in_range
+msgid "In Target"
+msgstr "อยู่ในเป้าหมาย"
 
 #. module: ni_goal
 #: model:ir.model.fields.selection,name:ni_goal.selection__ni_goal_achievement__decoration__info
@@ -719,6 +768,24 @@ msgid "Min"
 msgstr "ต่ำสุด"
 
 #. module: ni_goal
+#: model:ir.model.fields,help:ni_goal.field_ni_goal_code__target_ratio_min
+msgid ""
+"Multiplier applied to the patient's current observation value to get the "
+"target lower bound when Target Type is 'Ratio'."
+msgstr ""
+"ตัวคูณที่ใช้กับค่าที่วัดได้ล่าสุดของผู้รับบริการเพื่อหาขอบเขตล่างของเป้าหมายเมื่อประเภทเป้าหมายเป็น "
+"'อัตราส่วน'"
+
+#. module: ni_goal
+#: model:ir.model.fields,help:ni_goal.field_ni_goal_code__target_ratio_max
+msgid ""
+"Multiplier applied to the patient's current observation value to get the "
+"target upper bound when Target Type is 'Ratio'."
+msgstr ""
+"ตัวคูณที่ใช้กับค่าที่วัดได้ล่าสุดของผู้รับบริการเพื่อหาขอบเขตบนของเป้าหมายเมื่อประเภทเป้าหมายเป็น "
+"'อัตราส่วน'"
+
+#. module: ni_goal
 #: model:ir.model.fields.selection,name:ni_goal.selection__ni_goal_achievement__decoration__muted
 #: model:ir.model.fields.selection,name:ni_goal.selection__ni_goal_state__decoration__muted
 msgid "Muted"
@@ -773,6 +840,20 @@ msgstr "ไม่เปลี่ยนแปลง"
 #: model:ni.goal.achievement,name:ni_goal.goal_no_progress
 msgid "No Progress"
 msgstr "ไม่มีความคืบหน้า"
+
+#. module: ni_goal
+#. odoo-python
+#: code:addons/ni_goal/models/ni_goal.py:0
+#, python-format
+msgid "No baseline measurement has been recorded for this target yet."
+msgstr "ยังไม่มีการบันทึกค่าเริ่มต้น (Baseline) สำหรับเป้าหมายนี้"
+
+#. module: ni_goal
+#. odoo-python
+#: code:addons/ni_goal/models/ni_goal.py:0
+#, python-format
+msgid "No measurement has been recorded since the baseline value yet."
+msgstr "ยังไม่มีการวัดค่าใหม่นับตั้งแต่ค่าเริ่มต้น (Baseline)"
 
 #. module: ni_goal
 #: model:ni.goal.achievement,name:ni_goal.goal_not_achieved
@@ -868,6 +949,11 @@ msgstr "เป้าหมายระหว่างดำเนินการ
 #: model:ir.model.fields,field_description:ni_goal.field_ni_goal_state_wizard__target_code_operator
 msgid "Operator"
 msgstr "ตัวดำเนินการ"
+
+#. module: ni_goal
+#: model:ir.model.fields.selection,name:ni_goal.selection__ni_goal__target_status__out_of_range
+msgid "Out of Target"
+msgstr "ไม่อยู่ในเป้าหมาย"
 
 #. module: ni_goal
 #: model:ir.model.fields,field_description:ni_goal.field_ni_goal__outcome_observation_id
@@ -1075,6 +1161,12 @@ msgid "Target"
 msgstr "เป้าหมาย"
 
 #. module: ni_goal
+#: model:ir.model.fields,field_description:ni_goal.field_ni_goal__target_alert_message
+#: model:ir.model.fields,field_description:ni_goal.field_ni_goal_state_wizard__target_alert_message
+msgid "Target Alert Message"
+msgstr "ข้อความแจ้งเตือนเป้าหมาย"
+
+#. module: ni_goal
 #: model:ir.model.fields,field_description:ni_goal.field_ni_goal__target_code_ids
 #: model:ir.model.fields,field_description:ni_goal.field_ni_goal_code__target_code_ids
 #: model:ir.model.fields,field_description:ni_goal.field_ni_goal_state_wizard__target_code_ids
@@ -1097,6 +1189,12 @@ msgstr "เป้าหมายสูงสุด"
 #: model:ir.model.fields,field_description:ni_goal.field_ni_goal_state_wizard__target_min
 msgid "Target Min"
 msgstr "เป้าหมายต่ำสุด"
+
+#. module: ni_goal
+#: model:ir.model.fields,field_description:ni_goal.field_ni_goal__target_status
+#: model:ir.model.fields,field_description:ni_goal.field_ni_goal_state_wizard__target_status
+msgid "Target Status"
+msgstr "สถานะเป้าหมาย"
 
 #. module: ni_goal
 #: model:ir.model.fields,field_description:ni_goal.field_ni_goal_code__target_type
@@ -1209,9 +1307,10 @@ msgid "Type of the exception activity on record."
 msgstr ""
 
 #. module: ni_goal
-#: model:ir.model.fields,field_description:ni_goal.field_ni_goal_state_wizard__target_unit
+#: model:ir.model.fields,field_description:ni_goal.field_ni_goal__target_unit_id
+#: model:ir.model.fields,field_description:ni_goal.field_ni_goal_state_wizard__target_unit_id
 msgid "Unit"
-msgstr ""
+msgstr "หน่วย"
 
 #. module: ni_goal
 #: model:ir.model.fields,field_description:ni_goal.field_ni_goal__period_end

--- a/ni_goal/models/ni_goal.py
+++ b/ni_goal/models/ni_goal.py
@@ -83,6 +83,11 @@ class Goal(models.Model):
             ("not in", "Not Contain"),
         ],
         "Operator",
+        help="How the observed value(s) must relate to the target codes: "
+        "'Match'/'Not Match' compare the observed values against the target set exactly (order doesn't matter); "
+        "'Contain'/'Not Contain' require every observed value to be (not be) a member of the target set; "
+        "'Child of'/'Parent of' require every observed value to be a descendant/ancestor (or itself) of some target "
+        "value, walking the target codes' parent hierarchy.",
     )
     target_code_ids = fields.Many2many(
         "ni.observation.value.code", domain="[('type_ids', '=', observation_type_id)]"
@@ -105,6 +110,11 @@ class Goal(models.Model):
         tracking=True,
         ondelete="set null",
     )
+    target_status = fields.Selection(
+        [("in_range", "In Target"), ("out_of_range", "Out of Target")],
+        compute="_compute_target_status",
+    )
+    target_alert_message = fields.Char(compute="_compute_target_status")
     condition_ids = fields.Many2many(
         "ni.condition",
         "ni_goal_addresses_condition",
@@ -183,6 +193,69 @@ class Goal(models.Model):
                         "observation_ids": [fields.Command.set(obs.ids)],
                     }
                 )
+
+    @api.depends(
+        "observation_id",
+        "address_observation_id",
+        "target_value_type",
+        "target_min",
+        "target_max",
+        "target_code_operator",
+        "target_code_ids",
+    )
+    def _compute_target_status(self):
+        for rec in self:
+            rec.target_status = False
+            rec.target_alert_message = False
+            if not rec.observation_type_id:
+                continue
+            obs = rec.observation_id
+            if obs:
+                rec.target_status = rec._match_target(obs)
+            if not rec.address_observation_id:
+                rec.target_alert_message = _(
+                    "No baseline measurement has been recorded for this target yet."
+                )
+            elif obs and obs == rec.address_observation_id:
+                rec.target_alert_message = _(
+                    "No measurement has been recorded since the baseline value yet."
+                )
+
+    def _match_target(self, obs):
+        self.ensure_one()
+        if self.target_value_type == "float":
+            in_range = self.target_min <= obs.value_float <= self.target_max
+        elif self.target_value_type == "int":
+            in_range = self.target_min <= obs.value_int <= self.target_max
+        elif self.target_value_type == "code_id":
+            in_range = self._match_target_code(obs.value_code_id)
+        elif self.target_value_type == "code_ids":
+            in_range = self._match_target_code(obs.value_code_ids)
+        else:
+            return False
+        return "in_range" if in_range else "out_of_range"
+
+    def _match_target_code(self, value_codes):
+        self.ensure_one()
+        operator = self.target_code_operator
+        targets = self.target_code_ids
+        if not operator or not targets or not value_codes:
+            return False
+        if operator == "=":
+            return value_codes == targets
+        if operator == "!=":
+            return value_codes != targets
+        if operator == "in":
+            return value_codes <= targets
+        if operator == "not in":
+            return not bool(value_codes & targets)
+        if operator == "child_of":
+            matched = value_codes.filtered_domain([("id", "child_of", targets.ids)])
+            return matched == value_codes
+        if operator == "parent_of":
+            matched = value_codes.filtered_domain([("id", "parent_of", targets.ids)])
+            return matched == value_codes
+        return False
 
     @api.model
     def _expand_state_ids(self, states, domain, order):

--- a/ni_goal/models/ni_goal_code.py
+++ b/ni_goal/models/ni_goal_code.py
@@ -21,11 +21,31 @@ class GoalCodeableConcept(models.Model):
         domain=[("value_type", "in", ["int", "float", "code_id", "code_ids"])],
     )
     target_value_type = fields.Selection(related="observation_type_id.value_type")
-    target_type = fields.Selection([("fix", "Fix Value"), ("ratio", "Ratio")])
-    target_fix_min = fields.Float("Min")
-    target_fix_max = fields.Float("Max")
-    target_ratio_min = fields.Float("Ratio Min", default=1.0)
-    target_ratio_max = fields.Float("Ratio Max", default=1.0)
+    target_type = fields.Selection(
+        [("fix", "Fix Value"), ("ratio", "Ratio")],
+        help="How the numeric target range (target_min/target_max) is derived when this template is applied to a "
+        "goal: 'Fix Value' copies target_fix_min/target_fix_max as-is; 'Ratio' multiplies the patient's current "
+        "observation value by target_ratio_min/target_ratio_max (e.g. a ratio of 0.9-1.1 targets within 90%-110% "
+        "of the patient's value at the time the goal is created).",
+    )
+    target_fix_min = fields.Float(
+        "Min", help="Fixed lower bound applied when Target Type is 'Fix Value'."
+    )
+    target_fix_max = fields.Float(
+        "Max", help="Fixed upper bound applied when Target Type is 'Fix Value'."
+    )
+    target_ratio_min = fields.Float(
+        "Ratio Min",
+        default=1.0,
+        help="Multiplier applied to the patient's current observation value to get the target lower bound when "
+        "Target Type is 'Ratio'.",
+    )
+    target_ratio_max = fields.Float(
+        "Ratio Max",
+        default=1.0,
+        help="Multiplier applied to the patient's current observation value to get the target upper bound when "
+        "Target Type is 'Ratio'.",
+    )
 
     target_code_operator = fields.Selection(
         [
@@ -37,6 +57,11 @@ class GoalCodeableConcept(models.Model):
             ("not in", "Not Contain"),
         ],
         "Operator",
+        help="How the observed value(s) must relate to the target codes: "
+        "'Match'/'Not Match' compare the observed values against the target set exactly (order doesn't matter); "
+        "'Contain'/'Not Contain' require every observed value to be (not be) a member of the target set; "
+        "'Child of'/'Parent of' require every observed value to be a descendant/ancestor (or itself) of some target "
+        "value, walking the target codes' parent hierarchy.",
     )
     target_code_ids = fields.Many2many(
         "ni.observation.value.code",

--- a/ni_goal/tests/__init__.py
+++ b/ni_goal/tests/__init__.py
@@ -1,0 +1,3 @@
+#  Copyright (c) 2026 NSTDA
+
+from . import test_target_status

--- a/ni_goal/tests/test_target_status.py
+++ b/ni_goal/tests/test_target_status.py
@@ -1,0 +1,314 @@
+#  Copyright (c) 2026 NSTDA
+
+from odoo.tests import common
+
+
+class TestGoalTargetStatus(common.TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        partner = cls.env["res.partner"].create({"name": "Target Status Patient"})
+        cls.patient = cls.env["ni.patient"].create({"partner_id": partner.id})
+        cls.state_active = cls.env.ref("ni_goal.goal_state_active")
+
+        cls.type_numeric = cls.env["ni.observation.type"].create(
+            {
+                "name": "Test Numeric Measure",
+                "code": "test-goal-numeric",
+                "value_type": "float",
+                "min": 0,
+                "max": 9999,
+            }
+        )
+        cls.type_coded = cls.env["ni.observation.type"].create(
+            {
+                "name": "Test Coded Measure",
+                "code": "test-goal-coded",
+                "value_type": "code_id",
+            }
+        )
+        cls.code_ok = cls.env["ni.observation.value.code"].create(
+            {"name": "OK", "type_ids": [(6, 0, [cls.type_coded.id])]}
+        )
+        cls.code_bad = cls.env["ni.observation.value.code"].create(
+            {"name": "BAD", "type_ids": [(6, 0, [cls.type_coded.id])]}
+        )
+        cls.code_child = cls.env["ni.observation.value.code"].create(
+            {
+                "name": "OK Child",
+                "type_ids": [(6, 0, [cls.type_coded.id])],
+                "parent_id": cls.code_ok.id,
+            }
+        )
+        cls.type_coded_multi = cls.env["ni.observation.type"].create(
+            {
+                "name": "Test Multi Coded Measure",
+                "code": "test-goal-coded-multi",
+                "value_type": "code_ids",
+            }
+        )
+        (cls.code_ok + cls.code_bad + cls.code_child).write(
+            {"type_ids": [(4, cls.type_coded_multi.id)]}
+        )
+        cls.code_x = cls.env["ni.observation.value.code"].create(
+            {"name": "X", "type_ids": [(6, 0, [cls.type_coded_multi.id])]}
+        )
+        cls.code_y = cls.env["ni.observation.value.code"].create(
+            {"name": "Y", "type_ids": [(6, 0, [cls.type_coded_multi.id])]}
+        )
+
+    def _make_obs(self, ob_type, occurrence, **values):
+        return self.env["ni.observation"].create(
+            {
+                "patient_id": self.patient.id,
+                "type_id": ob_type.id,
+                "occurrence": occurrence,
+                **values,
+            }
+        )
+
+    def _make_goal(self, ob_type, **values):
+        return self.env["ni.goal"].create(
+            {
+                "name": "Test Goal",
+                "patient_id": self.patient.id,
+                "state_id": self.state_active.id,
+                "observation_type_id": ob_type.id,
+                **values,
+            }
+        )
+
+    # ── numeric target ────────────────────────────────────────────────────
+
+    def test_numeric_value_in_range(self):
+        goal = self._make_goal(self.type_numeric, target_min=0, target_max=100)
+        self._make_obs(self.type_numeric, "2026-01-01 00:00:00", value_float=50.0)
+        goal.invalidate_recordset()
+
+        self.assertEqual(goal.target_status, "in_range")
+
+    def test_numeric_value_out_of_range(self):
+        goal = self._make_goal(self.type_numeric, target_min=0, target_max=100)
+        self._make_obs(self.type_numeric, "2026-01-01 00:00:00", value_float=500.0)
+        goal.invalidate_recordset()
+
+        self.assertEqual(goal.target_status, "out_of_range")
+
+    def test_no_status_without_measurement(self):
+        goal = self._make_goal(self.type_numeric, target_min=0, target_max=100)
+
+        self.assertFalse(goal.target_status)
+
+    # ── coded target ──────────────────────────────────────────────────────
+
+    def test_coded_value_matches_target(self):
+        goal = self._make_goal(
+            self.type_coded,
+            target_code_operator="=",
+            target_code_ids=[(6, 0, [self.code_ok.id])],
+        )
+        self._make_obs(
+            self.type_coded, "2026-01-01 00:00:00", value_code_id=self.code_ok.id
+        )
+        goal.invalidate_recordset()
+
+        self.assertEqual(goal.target_status, "in_range")
+
+    def test_coded_value_does_not_match_target(self):
+        goal = self._make_goal(
+            self.type_coded,
+            target_code_operator="=",
+            target_code_ids=[(6, 0, [self.code_ok.id])],
+        )
+        self._make_obs(
+            self.type_coded, "2026-01-01 00:00:00", value_code_id=self.code_bad.id
+        )
+        goal.invalidate_recordset()
+
+        self.assertEqual(goal.target_status, "out_of_range")
+
+    def test_coded_value_matches_child_of_target(self):
+        goal = self._make_goal(
+            self.type_coded,
+            target_code_operator="child_of",
+            target_code_ids=[(6, 0, [self.code_ok.id])],
+        )
+        self._make_obs(
+            self.type_coded, "2026-01-01 00:00:00", value_code_id=self.code_child.id
+        )
+        goal.invalidate_recordset()
+
+        self.assertEqual(goal.target_status, "in_range")
+
+    def test_coded_value_matches_parent_of_target(self):
+        goal = self._make_goal(
+            self.type_coded,
+            target_code_operator="parent_of",
+            target_code_ids=[(6, 0, [self.code_child.id])],
+        )
+        self._make_obs(
+            self.type_coded, "2026-01-01 00:00:00", value_code_id=self.code_ok.id
+        )
+        goal.invalidate_recordset()
+
+        self.assertEqual(goal.target_status, "in_range")
+
+    # ── coded target: multi-value (code_ids) set semantics ─────────────────
+
+    def test_coded_ids_equal_same_members_matches(self):
+        goal = self._make_goal(
+            self.type_coded_multi,
+            target_code_operator="=",
+            target_code_ids=[(6, 0, [self.code_x.id, self.code_y.id])],
+        )
+        self._make_obs(
+            self.type_coded_multi,
+            "2026-01-01 00:00:00",
+            value_code_ids=[(6, 0, [self.code_y.id, self.code_x.id])],
+        )
+        goal.invalidate_recordset()
+
+        self.assertEqual(goal.target_status, "in_range")
+
+    def test_coded_ids_equal_extra_member_does_not_match(self):
+        goal = self._make_goal(
+            self.type_coded_multi,
+            target_code_operator="=",
+            target_code_ids=[(6, 0, [self.code_x.id])],
+        )
+        self._make_obs(
+            self.type_coded_multi,
+            "2026-01-01 00:00:00",
+            value_code_ids=[(6, 0, [self.code_x.id, self.code_y.id])],
+        )
+        goal.invalidate_recordset()
+
+        self.assertEqual(goal.target_status, "out_of_range")
+
+    def test_coded_ids_in_subset_matches(self):
+        goal = self._make_goal(
+            self.type_coded_multi,
+            target_code_operator="in",
+            target_code_ids=[(6, 0, [self.code_x.id, self.code_y.id])],
+        )
+        self._make_obs(
+            self.type_coded_multi,
+            "2026-01-01 00:00:00",
+            value_code_ids=[(6, 0, [self.code_x.id])],
+        )
+        goal.invalidate_recordset()
+
+        self.assertEqual(goal.target_status, "in_range")
+
+    def test_coded_ids_in_member_outside_target_does_not_match(self):
+        goal = self._make_goal(
+            self.type_coded_multi,
+            target_code_operator="in",
+            target_code_ids=[(6, 0, [self.code_x.id])],
+        )
+        self._make_obs(
+            self.type_coded_multi,
+            "2026-01-01 00:00:00",
+            value_code_ids=[(6, 0, [self.code_x.id, self.code_y.id])],
+        )
+        goal.invalidate_recordset()
+
+        self.assertEqual(goal.target_status, "out_of_range")
+
+    def test_coded_ids_not_in_disjoint_matches(self):
+        goal = self._make_goal(
+            self.type_coded_multi,
+            target_code_operator="not in",
+            target_code_ids=[(6, 0, [self.code_x.id])],
+        )
+        self._make_obs(
+            self.type_coded_multi,
+            "2026-01-01 00:00:00",
+            value_code_ids=[(6, 0, [self.code_y.id])],
+        )
+        goal.invalidate_recordset()
+
+        self.assertEqual(goal.target_status, "in_range")
+
+    def test_coded_ids_not_in_overlap_does_not_match(self):
+        goal = self._make_goal(
+            self.type_coded_multi,
+            target_code_operator="not in",
+            target_code_ids=[(6, 0, [self.code_x.id])],
+        )
+        self._make_obs(
+            self.type_coded_multi,
+            "2026-01-01 00:00:00",
+            value_code_ids=[(6, 0, [self.code_x.id, self.code_y.id])],
+        )
+        goal.invalidate_recordset()
+
+        self.assertEqual(goal.target_status, "out_of_range")
+
+    def test_coded_ids_child_of_requires_all_members_to_match(self):
+        goal = self._make_goal(
+            self.type_coded_multi,
+            target_code_operator="child_of",
+            target_code_ids=[(6, 0, [self.code_ok.id])],
+        )
+        self._make_obs(
+            self.type_coded_multi,
+            "2026-01-01 00:00:00",
+            value_code_ids=[(6, 0, [self.code_child.id, self.code_bad.id])],
+        )
+        goal.invalidate_recordset()
+
+        self.assertEqual(
+            goal.target_status,
+            "out_of_range",
+            "code_bad is not a descendant of code_ok, so not all members match",
+        )
+
+    def test_coded_ids_child_of_all_members_match(self):
+        goal = self._make_goal(
+            self.type_coded_multi,
+            target_code_operator="child_of",
+            target_code_ids=[(6, 0, [self.code_ok.id])],
+        )
+        self._make_obs(
+            self.type_coded_multi,
+            "2026-01-01 00:00:00",
+            value_code_ids=[(6, 0, [self.code_child.id, self.code_ok.id])],
+        )
+        goal.invalidate_recordset()
+
+        self.assertEqual(goal.target_status, "in_range")
+
+    # ── alert messages ───────────────────────────────────────────────────
+
+    def test_alert_no_baseline_yet(self):
+        goal = self._make_goal(self.type_numeric, target_min=0, target_max=100)
+        self._make_obs(self.type_numeric, "2026-01-01 00:00:00", value_float=50.0)
+        goal.invalidate_recordset()
+
+        self.assertFalse(goal.address_observation_id)
+        self.assertIn("baseline", goal.target_alert_message)
+
+    def test_alert_no_measurement_since_baseline(self):
+        goal = self._make_goal(self.type_numeric, target_min=0, target_max=100)
+        obs = self._make_obs(self.type_numeric, "2026-01-01 00:00:00", value_float=50.0)
+        goal.invalidate_recordset()
+        goal.write({"address_observation_id": obs.id})
+        goal.invalidate_recordset()
+
+        self.assertEqual(goal.observation_id, obs)
+        self.assertIn("since the baseline", goal.target_alert_message)
+
+    def test_no_alert_when_measured_after_baseline(self):
+        goal = self._make_goal(self.type_numeric, target_min=0, target_max=100)
+        baseline = self._make_obs(
+            self.type_numeric, "2026-01-01 00:00:00", value_float=50.0
+        )
+        goal.invalidate_recordset()
+        goal.write({"address_observation_id": baseline.id})
+        self._make_obs(self.type_numeric, "2026-02-01 00:00:00", value_float=60.0)
+        goal.invalidate_recordset()
+
+        self.assertNotEqual(goal.observation_id, baseline)
+        self.assertFalse(goal.target_alert_message)

--- a/ni_goal/views/ni_goal_views.xml
+++ b/ni_goal/views/ni_goal_views.xml
@@ -152,6 +152,12 @@
                                 </group>
                                 <group>
                                     <field name="observation_id" options="{'no_open': True}" />
+                                    <field
+                                        name="target_status"
+                                        widget="badge"
+                                        decoration-success="target_status == 'in_range'"
+                                        decoration-danger="target_status == 'out_of_range'"
+                                    />
                                 </group>
                             </group>
                             <separator string="History" />

--- a/ni_goal/wizards/ni_goal_state_wizard.py
+++ b/ni_goal/wizards/ni_goal_state_wizard.py
@@ -27,6 +27,8 @@ class GoalStateWizard(models.TransientModel):
     target_unit_id = fields.Many2one(related="goal_id.observation_type_id.unit_id")
     target_code_operator = fields.Selection(related="goal_id.target_code_operator")
     target_code_ids = fields.Many2many(related="goal_id.target_code_ids")
+    target_status = fields.Selection(related="goal_id.target_status")
+    target_alert_message = fields.Char(related="goal_id.target_alert_message")
     address_observation_id = fields.Many2one(related="goal_id.address_observation_id")
     address_occurrence = fields.Datetime(
         related="goal_id.address_observation_id.occurrence"

--- a/ni_goal/wizards/ni_goal_state_wizard_views.xml
+++ b/ni_goal/wizards/ni_goal_state_wizard_views.xml
@@ -47,8 +47,22 @@
                     <group attrs="{'invisible': [('observation_id', '=', False)]}">
                         <field name="observation_id" string="Latest" readonly="1" options="{'no_open': True}" />
                         <field name="observation_occurrence" string="Date" readonly="1" />
+                        <field
+                            name="target_status"
+                            widget="badge"
+                            decoration-success="target_status == 'in_range'"
+                            decoration-danger="target_status == 'out_of_range'"
+                        />
                     </group>
                 </group>
+                <div
+                    class="alert alert-warning mb-2 d-flex align-items-center"
+                    role="alert"
+                    attrs="{'invisible': [('target_alert_message', '=', False)]}"
+                >
+                    <i class="fa fa-exclamation-triangle text-danger me-2" />
+                    <field name="target_alert_message" nolabel="1" readonly="1" />
+                </div>
                 <group class="mt-4" string="State &amp; Achievement">
                     <group>
                         <field name="state_id" options="{'no_open': True}" />


### PR DESCRIPTION
## What changed

- `ni_goal`: added computed `target_status` ("In Target"/"Out of Target" badge) and `target_alert_message` (warns when there's no measurement yet, or none since baseline) on `ni.goal`, shown on the goal form and the state wizard.
- `ni_goal`: added `help` text for `target_code_operator` (both `ni.goal` and `ni.goal.code`) and for `target_type`/`target_fix_min`/`target_fix_max`/`target_ratio_min`/`target_ratio_max` on `ni.goal.code`, plus a README spec section for both.

## Why
This closes the gap, and separately adds visibility (badge + alert) so a clinician can see whether a goal is currently in target and whether there's enough measurement evidence to judge progress.

## Scope

 `ni_goal` (models, views, wizard, tests, i18n, README).

## Risk / Impact

- `_match_target_code` behavior change: any existing goal already using `child_of`/`parent_of` target operators will see stricter/corrected matching (previously an approximate overlap test). No goals currently seeded use these operators.

## How tested

- [x] Unit/integration tests
- [x] Manual check
- [ ] Not tested / explain why:

## Documentation

- [x] `README.md` updated
- [ ] Not needed