### PR TITLE
[IMP] ni_service: improve service dashboard and reduce query counts

### DIFF
--- a/ni_community_care/models/ni_service.py
+++ b/ni_community_care/models/ni_service.py
@@ -1,4 +1,7 @@
 #  Copyright (c) 2024 NSTDA
+from collections import defaultdict
+from datetime import timedelta
+
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 
@@ -36,6 +39,33 @@ class Service(models.Model):
         if operator == "=":
             return [("user_id", "=" if bool(operand) else "!=", self.env.user.id)]
         raise ValidationError(_("my_service support only '=', 'True' or 'False'"))
+
+    def _get_dashboard_graph_patient_counts(self, range_start, range_end):
+        events = (
+            self.env["ni.service.event"]
+            .sudo()
+            .search_read(
+                [
+                    "|",
+                    ("service_id", "in", self.ids),
+                    ("service_ids", "in", self.ids),
+                    ("start", ">=", range_start),
+                    ("start", "<=", range_end),
+                ],
+                ["service_id", "service_ids", "start", "plan_patient_ids"],
+            )
+        )
+        counts = defaultdict(lambda: defaultdict(set))
+        for event in events:
+            event_date = event["start"].date()
+            week_start = event_date - timedelta(days=event_date.weekday())
+            service_ids = event["service_ids"] + (
+                [event["service_id"][0]] if event["service_id"] else []
+            )
+            for service_id in service_ids:
+                if service_id in self.ids:
+                    counts[service_id][week_start].update(event["plan_patient_ids"])
+        return counts
 
 
 class ServiceCalendar(models.Model):

--- a/ni_community_care/views/ni_community_care_menu.xml
+++ b/ni_community_care/views/ni_community_care_menu.xml
@@ -80,14 +80,14 @@
         id="community_service_menu"
         name="กิจกรรมส่วนกลาง"
         parent="ni_service.root_menu"
-        action="ni_community_care.ni_service_action_community"
+        action="ni_service_action_community"
         sequence="1"
     />
     <menuitem
         id="all_service_menu"
         name="กิจกรรมทั้งหมด"
         parent="ni_service.root_menu"
-        action="ni_community_care.ni_service_action_all"
+        action="ni_service_action_all"
         groups="ni_patient.group_admin"
         sequence="2"
     />

--- a/ni_community_care/views/ni_service_views.xml
+++ b/ni_community_care/views/ni_service_views.xml
@@ -7,7 +7,7 @@
         <field name="name">กิจกรรมของฉัน ศผ.03</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">ni.service</field>
-        <field name="view_mode">tree,form</field>
+        <field name="view_mode">kanban,tree,form</field>
         <field name="domain">[('my_service', '=', True)]</field>
         <field name="context">{'default_user_id': uid}</field>
         <field name="help" type="html">
@@ -18,7 +18,7 @@
         <field name="name">กิจกรรมทั้งหมด</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">ni.service</field>
-        <field name="view_mode">tree,form</field>
+        <field name="view_mode">tree,kanban,form</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">ไม่พบกิจกรรม</p>
         </field>
@@ -55,7 +55,7 @@
         <field name="name">กิจกรรมส่วนกลาง</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">ni.service</field>
-        <field name="view_mode">tree,form</field>
+        <field name="view_mode">kanban,tree,form</field>
         <field name="context">{'search_default_service': 1, 'no_create_event': 0}</field>
         <field name="domain">[('user_id', '=', False)]</field>
         <field

--- a/ni_service/models/ni_encounter_service_attendance.py
+++ b/ni_service/models/ni_encounter_service_attendance.py
@@ -2,7 +2,7 @@
 
 from pytz import timezone
 
-from odoo import api, fields, models
+from odoo import api, fields, models, tools
 
 
 class EncounterServiceAttendance(models.Model):
@@ -15,7 +15,9 @@ class EncounterServiceAttendance(models.Model):
     patient_id = fields.Many2one(
         related="encounter_id.patient_id", store=True, index=True
     )
-    encounter_date = fields.Datetime(related="encounter_id.period_start", string="Date")
+    encounter_date = fields.Datetime(
+        related="encounter_id.period_start", string="Date", store=True, index=True
+    )
     dayofweek = fields.Selection(
         [
             ("0", "Monday"),
@@ -87,6 +89,14 @@ class EncounterServiceAttendance(models.Model):
             "The attendance time must be unique!",
         ),
     ]
+
+    def init(self):
+        tools.create_index(
+            self._cr,
+            f"{self._table}_service_id_encounter_date_idx",
+            self._table,
+            ["service_id", "encounter_date"],
+        )
 
     @api.depends("encounter_id", "encounter_date")
     def _compute_dayofweek(self):

--- a/ni_service/models/ni_service.py
+++ b/ni_service/models/ni_service.py
@@ -198,12 +198,20 @@ class Service(models.Model):
     def _compute_date(self):
         now = fields.Datetime.now()
         today = now.replace(hour=0, minute=0, second=0)
-        event = self.env["ni.service.event"].sudo()
-        for rec in self:
-            event = event.search(
-                [("service_id", "=", rec.id), ("start", ">", today)], limit=1
+        events = (
+            self.env["ni.service.event"]
+            .sudo()
+            .search(
+                [("service_id", "in", self.ids), ("start", ">", today)],
+                order="service_id, start",
             )
-            rec.next_date = event.start.date() if event else None
+        )
+        next_start = {}
+        for event in events:
+            next_start.setdefault(event.service_id.id, event.start)
+        for rec in self:
+            start = next_start.get(rec.id)
+            rec.next_date = start.date() if start else None
 
     @api.onchange("attendance_ids")
     def _onchange_attendance_ids(self):

--- a/ni_service/models/ni_service.py
+++ b/ni_service/models/ni_service.py
@@ -1,4 +1,10 @@
 #  Copyright (c) 2024 NSTDA
+import json
+from collections import defaultdict
+from datetime import timedelta
+
+from babel.dates import format_date
+
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 
@@ -74,6 +80,7 @@ class Service(models.Model):
         default="0",
     )
     next_date = fields.Date(compute="_compute_date")
+    dashboard_graph_data = fields.Text(compute="_compute_dashboard_graph_data")
     encounter_ids = fields.Many2many(
         "ni.encounter", domain="[('company_id', '=', company_id)]"
     )
@@ -99,6 +106,7 @@ class Service(models.Model):
         default=True, help="Indicate user can edit this service or not when generate"
     )
     event_ids = fields.One2many("ni.service.event", "service_id")
+    event_count = fields.Integer(compute="_compute_event_count")
     active = fields.Boolean(default=True)
 
     _sql_constraints = [
@@ -213,6 +221,84 @@ class Service(models.Model):
             start = next_start.get(rec.id)
             rec.next_date = start.date() if start else None
 
+    def _get_dashboard_graph_color(self):
+        self.ensure_one()
+        return "#7c7bad"
+
+    def _dashboard_graph_week_label(self, week_start, locale):
+        week_end = week_start + timedelta(days=6)
+        if week_end.month == week_start.month:
+            short_name_from = format_date(week_start, "d", locale=locale)
+        else:
+            short_name_from = format_date(week_start, "d MMM", locale=locale)
+        short_name_to = format_date(week_end, "d MMM", locale=locale)
+        return f"{short_name_from}-{short_name_to}"
+
+    def _get_dashboard_graph_patient_counts(self, range_start, range_end):
+        """Return {service_id: {week_start: {patient_id, ...}}} for the given range.
+
+        Override to change the data source (e.g. planned vs. actual attendance).
+        """
+        attendances = (
+            self.env["ni.encounter.service.attendance"]
+            .sudo()
+            .search_read(
+                [
+                    "|",
+                    ("service_id", "in", self.ids),
+                    ("service_ids", "in", self.ids),
+                    ("encounter_date", ">=", range_start),
+                    ("encounter_date", "<=", range_end),
+                ],
+                ["service_id", "service_ids", "encounter_date", "patient_id"],
+            )
+        )
+        counts = defaultdict(lambda: defaultdict(set))
+        for att in attendances:
+            att_date = att["encounter_date"].date()
+            week_start = att_date - timedelta(days=att_date.weekday())
+            service_ids = att["service_ids"] + (
+                [att["service_id"][0]] if att["service_id"] else []
+            )
+            for service_id in service_ids:
+                if service_id in self.ids:
+                    counts[service_id][week_start].add(att["patient_id"][0])
+        return counts
+
+    def _compute_dashboard_graph_data(self):
+        weeks_back = 4
+        today = fields.Date.context_today(self)
+        monday = today - timedelta(days=today.weekday())
+        week_starts = [
+            monday - timedelta(weeks=w) for w in range(weeks_back - 1, -1, -1)
+        ]
+        range_start = week_starts[0]
+        range_end = monday + timedelta(days=6)
+
+        counts = self._get_dashboard_graph_patient_counts(range_start, range_end)
+
+        locale = self._context.get("lang") or "en_US"
+        for rec in self:
+            values = [
+                {
+                    "label": self._dashboard_graph_week_label(week_start, locale),
+                    "value": len(counts[rec.id][week_start]),
+                    "type": "past",
+                }
+                for week_start in week_starts
+            ]
+            rec.dashboard_graph_data = json.dumps(
+                [
+                    {
+                        "values": values,
+                        "area": True,
+                        "title": "",
+                        "key": _("Patients Attended"),
+                        "color": rec._get_dashboard_graph_color(),
+                    }
+                ]
+            )
+
     @api.onchange("attendance_ids")
     def _onchange_attendance_ids(self):
         for rec in self:
@@ -246,6 +332,16 @@ class Service(models.Model):
     def _compute_employee_count(self):
         for rec in self:
             rec.employee_count = len(rec.employee_ids)
+
+    @api.depends("event_ids")
+    def _compute_event_count(self):
+        events = self.env["ni.service.event"].sudo()
+        read = events.read_group(
+            [("service_id", "in", self.ids)], ["service_id"], ["service_id"]
+        )
+        data = {res["service_id"][0]: res["service_id_count"] for res in read}
+        for rec in self:
+            rec.event_count = data.get(rec.id, 0)
 
     def create_event(self):
         ctx = dict(self.env.context)

--- a/ni_service/models/ni_service_event.py
+++ b/ni_service/models/ni_service_event.py
@@ -1,4 +1,5 @@
 #  Copyright (c) 2024 NSTDA
+from collections import defaultdict
 from datetime import datetime, timedelta
 
 from pytz import timezone
@@ -184,23 +185,28 @@ class ServiceEvent(models.Model):
             self._table,
             ["event_id", "id"],
         )
-
-    def _get_attachments_search_domain(self):
-        self.ensure_one()
-        return [("res_id", "=", self.id), ("res_model", "=", "ni.service.event")]
+        tools.create_index(
+            self._cr,
+            f"{self._table}_service_id_start_id_idx",
+            self._table,
+            ["service_id", "start", "id"],
+        )
 
     def _compute_attachment_ids(self):
+        attachments = self.env["ir.attachment"].search(
+            [("res_model", "=", "ni.service.event"), ("res_id", "in", self.ids)]
+        )
+        attachment_ids_by_task = defaultdict(set)
+        for attachment in attachments:
+            attachment_ids_by_task[attachment.res_id].add(attachment.id)
+
         for task in self:
-            attachment_ids = (
-                self.env["ir.attachment"]
-                .search(task._get_attachments_search_domain())
-                .ids
-            )
+            attachment_ids = attachment_ids_by_task.get(task.id, set())
             message_attachment_ids = task.mapped(
                 "message_ids.attachment_ids"
             ).ids  # from mail_thread
             task.attachment_ids = [
-                (6, 0, list(set(attachment_ids) - set(message_attachment_ids)))
+                (6, 0, list(attachment_ids - set(message_attachment_ids)))
             ]
             task.has_image = bool(attachment_ids)
 

--- a/ni_service/models/ni_service_request.py
+++ b/ni_service/models/ni_service_request.py
@@ -1,5 +1,7 @@
 #  Copyright (c) 2024 NSTDA
 
+from collections import defaultdict
+
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
@@ -46,10 +48,18 @@ class ServiceRequest(models.Model):
 
     @api.depends("attendance_ids.service_event_id")
     def _compute_event_count(self):
+        attendances = self.env["ni.encounter.service.attendance"].sudo()
+        grp = attendances.read_group(
+            [("request_id", "in", self.ids), ("service_event_id", "!=", False)],
+            ["request_id", "service_event_id"],
+            ["request_id", "service_event_id"],
+            lazy=False,
+        )
+        data = defaultdict(set)
+        for res in grp:
+            data[res["request_id"][0]].add(res["service_event_id"][0])
         for rec in self:
-            rec.event_count = len(
-                rec.attendance_ids.mapped("service_event_id").filtered("id")
-            )
+            rec.event_count = len(data.get(rec.id, ()))
 
     def action_view_events(self):
         self.ensure_one()

--- a/ni_service/views/ni_service_views.xml
+++ b/ni_service/views/ni_service_views.xml
@@ -68,6 +68,76 @@
             </tree>
         </field>
     </record>
+    <record id="ni_service_view_kanban" model="ir.ui.view">
+        <field name="name">ni.service.view.kanban</field>
+        <field name="model">ni.service</field>
+        <field name="arch" type="xml">
+            <kanban limit="40">
+                <field name="color" />
+                <templates>
+                    <t t-name="kanban-box">
+                        <div
+                            t-attf-class="#{kanban_color(record.color.raw_value)} oe_kanban_card oe_kanban_global_click"
+                        >
+                            <div class="oe_kanban_content">
+                                <div class="d-flex align-items-start justify-content-between gap-2">
+                                    <strong class="o_kanban_record_title">
+                                        <field name="name" />
+                                    </strong>
+                                    <field
+                                        name="type_id"
+                                        widget="badge"
+                                        decoration-primary="type_decoration == 'primary'"
+                                        decoration-success="type_decoration == 'success'"
+                                        decoration-info="type_decoration == 'info'"
+                                        decoration-warning="type_decoration == 'warning'"
+                                        decoration-danger="type_decoration == 'danger'"
+                                        decoration-muted="type_decoration == 'muted'"
+                                    />
+                                    <field name="type_decoration" invisible="1" />
+                                </div>
+                                <div class="o_kanban_tags_section mt-1">
+                                    <field
+                                        name="category_ids"
+                                        widget="many2many_tags"
+                                        options="{'color_field': 'color'}"
+                                    />
+                                </div>
+                                <div class="text-muted small mt-1">
+                                    <i class="fa fa-clock-o mx-1" aria-hidden="true" title="Duration" />
+                                    <field name="duration" widget="float_time" />
+                                    hours
+                                </div>
+                                <div class="o_kanban_graph_section mt-1" t-if="record.dashboard_graph_data.raw_value">
+                                    <field
+                                        name="dashboard_graph_data"
+                                        widget="dashboard_graph"
+                                        t-att-graph_type="'bar'"
+                                    />
+                                </div>
+                                <div class="o_kanban_record_bottom mt-2 pt-1">
+                                    <div class="oe_kanban_bottom_left">
+                                        <button
+                                            name="create_event"
+                                            icon="fa-calendar"
+                                            type="object"
+                                            class="btn btn-sm btn-link"
+                                            title="Calendar"
+                                            invisible="context.get('no_create_event', True)"
+                                        />
+                                        <field name="next_date" />
+                                    </div>
+                                    <div class="oe_kanban_bottom_right">
+                                        <field name="employee_id" widget="many2one_avatar_employee" />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
     <record id="ni_service_view_form" model="ir.ui.view">
         <field name="name">ni.service.view.form</field>
         <field name="model">ni.service</field>
@@ -78,7 +148,15 @@
                 <header />
                 <sheet>
                     <div name="button_box" class="oe_button_box">
-                        <button name="create_event" icon="fa-calendar" type="object" string="calendar" />
+                        <button
+                            name="create_event"
+                            icon="fa-calendar"
+                            type="object"
+                            class="oe_stat_button"
+                            invisible="context.get('no_create_event', True)"
+                        >
+                            <field name="event_count" widget="statinfo" string="Events" />
+                        </button>
                     </div>
                     <div class="oe_title mb24">
                         <label for="name" />
@@ -179,6 +257,9 @@
                                 </tree>
                             </field>
                         </page>
+                        <page name="event" string="History" badge="event_count">
+                            <field name="event_ids" />
+                        </page>
                         <page name="extra" string="Extra Info" groups="base.group_no_one">
                             <group>
                                 <field name="sequence" />
@@ -195,7 +276,7 @@
         <field name="name">Services</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">ni.service</field>
-        <field name="view_mode">tree,form</field>
+        <field name="view_mode">kanban,tree,form</field>
         <field name="context">{'search_default_service': 1, 'no_create_event': 0}</field>
         <field name="help" type="html">
             <p class="oe_view_nocontent_create">No Service found</p>
@@ -205,7 +286,7 @@
         <field name="name">Routine Service</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">ni.service</field>
-        <field name="view_mode">tree,form</field>
+        <field name="view_mode">tree,kanban,form</field>
         <field name="context">{'search_default_routine': 1}</field>
         <field name="help" type="html">
             <p class="oe_view_nocontent_create">No Routine found</p>


### PR DESCRIPTION
## What changed

- Batches per-record queries in `ni.service`/`ni.service.event`/`ni.service.request` count computes into single searches/read_groups, with matching DB indexes.
- Adds a kanban view for `ni.service` with category/type badges, duration, next scheduled date, and a mini dashboard-graph widget showing distinct patients attended per week over the past 4 weeks. Stores and indexes `ni.encounter.service.attendance.encounter_date` to support it.
- `ni_community_care` overrides the dashboard graph to count planned patients (`ni.service.event.plan_patient_ids`) instead of actual attendance, since community care plans visits ahead of time.

## Why

The count computes ran one query per record, causing N+1 query load on service list/kanban views. The kanban dashboard also gives managers an at-a-glance attendance trend, which community care needs to reflect *planned* visits rather than completed encounters.

## Scope

`ni_service`, `ni_community_care`: service kanban/dashboard views, count computes, attendance indexing.

## Risk / Impact

Adds new DB indexes (`ni.service.event`, `ni.encounter.service.attendance`) — applied via module upgrade, no manual migration needed. `encounter_date` changes from a non-stored related field to stored; existing data will be recomputed on module update. No backward-incompatible API changes.

## How tested

- [ ] Unit/integration tests
- [x] Manual check
- [ ] Not tested / explain why:

Manual: verified kanban dashboard graph renders attendance/planned-patient counts correctly for both `ni_service` and `ni_community_care`, and confirmed count fields (event_count, attachment counts, next date) match pre-change values after the batching refactor.

## Documentation

- [ ] Module `README.md` updated
- [x] Not needed

## Notes for reviewer

-